### PR TITLE
feat: React 19 post-migration improvements

### DIFF
--- a/src/components/AccessListDetailsDialog.tsx
+++ b/src/components/AccessListDetailsDialog.tsx
@@ -34,12 +34,12 @@ interface AccessListDetailsDialogProps {
   onEdit?: (accessList: AccessList) => void
 }
 
-const AccessListDetailsDialog: React.FC<AccessListDetailsDialogProps> = ({
+const AccessListDetailsDialog = ({
   open,
   onClose,
   accessList,
   onEdit,
-}) => {
+}: AccessListDetailsDialogProps) => {
   const [copiedText, setCopiedText] = useState<string>('')
   // const [exportDialogOpen, setExportDialogOpen] = useState(false)
 

--- a/src/components/AdaptiveContainer.tsx
+++ b/src/components/AdaptiveContainer.tsx
@@ -27,7 +27,7 @@ interface AdaptiveContainerProps {
   fullWidth?: boolean
 }
 
-const AdaptiveContainer: React.FC<AdaptiveContainerProps> = ({
+const AdaptiveContainer = ({
   open,
   onClose,
   entity,
@@ -37,7 +37,7 @@ const AdaptiveContainer: React.FC<AdaptiveContainerProps> = ({
   actions,
   maxWidth = 'md',
   fullWidth = true
-}) => {
+}: AdaptiveContainerProps) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const { getContainerType, drawerPosition, drawerWidth } = useUISettingsStore()

--- a/src/components/CertificateDetailsDialog.tsx
+++ b/src/components/CertificateDetailsDialog.tsx
@@ -49,12 +49,12 @@ function TabPanel(props: TabPanelProps) {
   )
 }
 
-const CertificateDetailsDialog: React.FC<CertificateDetailsDialogProps> = ({
+const CertificateDetailsDialog = ({
   open,
   onClose,
   certificate,
   onEdit,
-}) => {
+}: CertificateDetailsDialogProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const { } = usePermissions() // eslint-disable-line no-empty-pattern

--- a/src/components/DataTable/DataTableToolbar.tsx
+++ b/src/components/DataTable/DataTableToolbar.tsx
@@ -100,8 +100,8 @@ export default function DataTableToolbar({
           )}
 
           {filters.map((filter) => {
-            const currentValue = activeFilters[filter.id] || filter.defaultValue || 'all'
-            const hasValue = currentValue !== 'all'
+            const currentValue = activeFilters[filter.id] ?? filter.defaultValue ?? ''
+            const hasValue = currentValue !== ''
             
             return (
               <FormControl 

--- a/src/components/DeadHostDetailsDialog.tsx
+++ b/src/components/DeadHostDetailsDialog.tsx
@@ -62,12 +62,12 @@ interface DeadHostDetailsDialogProps {
   onEdit?: (host: DeadHost) => void
 }
 
-const DeadHostDetailsDialog: React.FC<DeadHostDetailsDialogProps> = ({
+const DeadHostDetailsDialog = ({
   open,
   onClose,
   host,
   onEdit,
-}) => {
+}: DeadHostDetailsDialogProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const [activeTab, setActiveTab] = useState(0)

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -47,7 +47,7 @@ class ErrorBoundary extends Component<Props, State> {
                 An unexpected error has occurred. Please try refreshing the page.
               </Typography>
               
-              {process.env.NODE_ENV === 'development' && this.state.error && (
+              {import.meta.env.DEV && this.state.error && (
                 <Box sx={{ mt: 3, textAlign: 'left' }}>
                   <Alert severity="error" sx={{ mb: 2 }}>
                     <Typography variant="subtitle2" component="div">

--- a/src/components/LayoutWithSearch.tsx
+++ b/src/components/LayoutWithSearch.tsx
@@ -1,7 +1,7 @@
 import { GlobalSearchProvider } from '../contexts/GlobalSearchContext'
 import Layout from './Layout'
 
-const LayoutWithSearch: React.FC = () => {
+const LayoutWithSearch = () => {
   return (
     <GlobalSearchProvider>
       <Layout />

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -5,7 +5,7 @@ interface LogoProps {
   color?: string
 }
 
-const Logo: React.FC<LogoProps> = ({ width = 210, color = 'currentColor' }) => {
+const Logo = ({ width = 210, color = 'currentColor' }: LogoProps) => {
   // Calculate proportional dimensions
   const aspectRatio = 210 / 83
   const actualHeight = width / aspectRatio

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -6,7 +6,7 @@ interface PageHeaderProps {
   description: string
 }
 
-const PageHeader: React.FC<PageHeaderProps> = ({ icon, title, description }) => {
+const PageHeader = ({ icon, title, description }: PageHeaderProps) => {
   return (
     <Box display="flex" alignItems="center" gap={2} mb={3}>
       <Box sx={{ fontSize: '2.5rem' }}>

--- a/src/components/PermissionButton.tsx
+++ b/src/components/PermissionButton.tsx
@@ -10,7 +10,7 @@ interface PermissionButtonProps extends Omit<ButtonProps, 'action'> {
   tooltipWhenDisabled?: string
 }
 
-const PermissionButton: React.FC<PermissionButtonProps> = ({
+const PermissionButton = ({
   resource,
   level,
   permissionAction,
@@ -19,7 +19,7 @@ const PermissionButton: React.FC<PermissionButtonProps> = ({
   children,
   disabled,
   ...buttonProps
-}) => {
+}: PermissionButtonProps) => {
   const { hasPermission, canAccess } = useAuthStore()
 
   // Use either level-based or action-based permission check

--- a/src/components/PermissionGate.tsx
+++ b/src/components/PermissionGate.tsx
@@ -12,7 +12,7 @@ interface PermissionGateProps {
   tooltipText?: string
 }
 
-const PermissionGate: React.FC<PermissionGateProps> = ({
+const PermissionGate = ({
   children,
   resource,
   level,
@@ -20,7 +20,7 @@ const PermissionGate: React.FC<PermissionGateProps> = ({
   fallback = null,
   showTooltip = false,
   tooltipText
-}) => {
+}: PermissionGateProps) => {
   const { hasPermission, canAccess } = useAuthStore()
 
   // Use either level-based or action-based permission check

--- a/src/components/PermissionIconButton.tsx
+++ b/src/components/PermissionIconButton.tsx
@@ -11,7 +11,7 @@ interface PermissionIconButtonProps extends Omit<IconButtonProps, 'action'> {
   tooltipTitle?: string
 }
 
-const PermissionIconButton: React.FC<PermissionIconButtonProps> = ({
+const PermissionIconButton = ({
   resource,
   level,
   permissionAction,
@@ -21,7 +21,7 @@ const PermissionIconButton: React.FC<PermissionIconButtonProps> = ({
   children,
   disabled,
   ...iconButtonProps
-}) => {
+}: PermissionIconButtonProps) => {
   const { hasPermission, canAccess } = useAuthStore()
 
   // Use either level-based or action-based permission check

--- a/src/components/PermissionRoute.tsx
+++ b/src/components/PermissionRoute.tsx
@@ -7,11 +7,11 @@ interface PermissionRouteProps {
   level?: PermissionLevel
 }
 
-const PermissionRoute: React.FC<PermissionRouteProps> = ({ 
-  children, 
-  resource, 
-  level = 'view' 
-}) => {
+const PermissionRoute = ({
+  children,
+  resource,
+  level = 'view'
+}: PermissionRouteProps) => {
   return (
     <ProtectedRoute requiredResource={resource} requiredLevel={level}>
       {children}

--- a/src/components/ProxyHostDetailsDialog.tsx
+++ b/src/components/ProxyHostDetailsDialog.tsx
@@ -57,12 +57,12 @@ interface ProxyHostDetailsDialogProps {
   onEdit?: (host: ProxyHost) => void
 }
 
-const ProxyHostDetailsDialog: React.FC<ProxyHostDetailsDialogProps> = ({
+const ProxyHostDetailsDialog = ({
   open,
   onClose,
   host,
   onEdit,
-}) => {
+}: ProxyHostDetailsDialogProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const { } = usePermissions() // eslint-disable-line no-empty-pattern

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import logger from '../utils/logger'
 import {
@@ -71,7 +71,7 @@ const getStatusIcon = (status?: string) => {
   }
 }
 
-const SearchBar: React.FC = () => {
+const SearchBar = () => {
   const navigate = useNavigate()
   const theme = useTheme()
   
@@ -217,7 +217,7 @@ const SearchBar: React.FC = () => {
       noOptionsText={inputValue ? "No results found" : "Start typing to search..."}
       sx={{ width: '100%', maxWidth: 600 }}
       disablePortal={false}
-      componentsProps={{
+      slotProps={{
         popper: {
           placement: 'bottom-start',
           sx: {
@@ -292,7 +292,7 @@ const SearchBar: React.FC = () => {
             </ListItemIcon>
             <ListItemText
               primary={
-                <Box display="flex" alignItems="center" gap={1}>
+                <Box component="span" display="flex" alignItems="center" gap={1}>
                   {option.title}
                   {option.metadata?.ssl && (
                     <VpnKey sx={{ fontSize: 16, color: 'success.main' }} />
@@ -301,14 +301,14 @@ const SearchBar: React.FC = () => {
                 </Box>
               }
               secondary={
-                <Box>
+                <Box component="span">
                   {option.subtitle && (
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography variant="caption" component="span" color="text.secondary">
                       {option.subtitle}
                     </Typography>
                   )}
                   {option.metadata?.owner && (
-                    <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                    <Typography variant="caption" component="span" color="text.secondary" sx={{ ml: 1 }}>
                       • {option.metadata.owner}
                     </Typography>
                   )}

--- a/src/components/StreamDetailsDialog.tsx
+++ b/src/components/StreamDetailsDialog.tsx
@@ -32,12 +32,12 @@ interface StreamDetailsDialogProps {
   onEdit?: (stream: Stream) => void
 }
 
-const StreamDetailsDialog: React.FC<StreamDetailsDialogProps> = ({
+const StreamDetailsDialog = ({
   open,
   onClose,
   stream,
   onEdit,
-}) => {
+}: StreamDetailsDialogProps) => {
   const [copiedText, setCopiedText] = useState<string>('')
   // const [exportDialogOpen, setExportDialogOpen] = useState(false)
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,7 @@ import { IconButton, Tooltip } from '@mui/material'
 import { Brightness4, Brightness7 } from '@mui/icons-material'
 import { useTheme } from '../contexts/ThemeContext'
 
-const ThemeToggle: React.FC = () => {
+const ThemeToggle = () => {
   const { mode, toggleTheme } = useTheme()
 
   return (

--- a/src/components/UserDrawer.tsx
+++ b/src/components/UserDrawer.tsx
@@ -131,7 +131,7 @@ const PERMISSION_PRESETS: PermissionPreset[] = [
   },
 ]
 
-const UserDrawer: React.FC<UserDrawerProps> = ({ open, onClose, user, onSave }) => {
+const UserDrawer = ({ open, onClose, user, onSave }: UserDrawerProps) => {
   const [activeTab, setActiveTab] = useState(0)
   const [selectedPreset, setSelectedPreset] = useState<string>('custom')
   const { user: currentUser } = useAuthStore()

--- a/src/components/UserPasswordDialog.tsx
+++ b/src/components/UserPasswordDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -23,7 +23,7 @@ interface UserPasswordDialogProps {
   onSave: () => void
 }
 
-const UserPasswordDialog: React.FC<UserPasswordDialogProps> = ({ open, onClose, user, onSave }) => {
+const UserPasswordDialog = ({ open, onClose, user, onSave }: UserPasswordDialogProps) => {
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')

--- a/src/components/UserPermissionsDialog.tsx
+++ b/src/components/UserPermissionsDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -50,7 +50,7 @@ const defaultPermissions: Permissions = {
   certificates: 'manage',
 }
 
-const UserPermissionsDialog: React.FC<UserPermissionsDialogProps> = ({ open, onClose, user, onSave }) => {
+const UserPermissionsDialog = ({ open, onClose, user, onSave }: UserPermissionsDialogProps) => {
   const [permissions, setPermissions] = useState<Permissions>(defaultPermissions)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/src/components/base/BaseDialog.tsx
+++ b/src/components/base/BaseDialog.tsx
@@ -311,10 +311,12 @@ export default function BaseDialog({
           })
         }
       }}
-      BackdropProps={{
-        sx: {
-          backgroundColor: 'rgba(0, 0, 0, 0.4)',
-          backdropFilter: 'blur(2px)',
+      slotProps={{
+        backdrop: {
+          sx: {
+            backgroundColor: 'rgba(0, 0, 0, 0.4)',
+            backdropFilter: 'blur(2px)',
+          }
         }
       }}
     >

--- a/src/components/base/BaseDrawer.tsx
+++ b/src/components/base/BaseDrawer.tsx
@@ -135,7 +135,7 @@ export interface BaseDrawerProps {
  * </BaseDrawer>
  * ```
  */
-export const BaseDrawer: React.FC<BaseDrawerProps> = ({
+export const BaseDrawer = ({
   open,
   onClose,
   title,
@@ -162,7 +162,7 @@ export const BaseDrawer: React.FC<BaseDrawerProps> = ({
   className,
   disableBackdropClick = false,
   disableEscapeKeyDown = false,
-}) => {
+}: BaseDrawerProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [showConfirmClose, setShowConfirmClose] = useState(false);

--- a/src/components/features/certificates/CertificateActions.tsx
+++ b/src/components/features/certificates/CertificateActions.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Button } from '@mui/material'
 import { Edit as EditIcon } from '@mui/icons-material'
 import { Certificate } from '../../../api/certificates'
@@ -10,11 +9,11 @@ interface CertificateActionsProps {
   onEdit?: (certificate: Certificate) => void
 }
 
-const CertificateActions: React.FC<CertificateActionsProps> = ({
+const CertificateActions = ({
   certificate,
   onClose,
   onEdit,
-}) => {
+}: CertificateActionsProps) => {
   return (
     <>
       {onEdit && (

--- a/src/components/features/certificates/CertificateAdvancedPanel.tsx
+++ b/src/components/features/certificates/CertificateAdvancedPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Alert } from '@mui/material'
 import { Certificate } from '../../../api/certificates'
 
@@ -6,9 +5,9 @@ interface CertificateAdvancedPanelProps {
   certificate: Certificate
 }
 
-const CertificateAdvancedPanel: React.FC<CertificateAdvancedPanelProps> = ({
+const CertificateAdvancedPanel = ({
   certificate: _certificate,
-}) => {
+}: CertificateAdvancedPanelProps) => {
   return (
     <Alert severity="info">
       Advanced certificate information and raw certificate data will be displayed here in the future.

--- a/src/components/features/certificates/CertificateHostsPanel.tsx
+++ b/src/components/features/certificates/CertificateHostsPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Box,
@@ -20,10 +19,10 @@ interface CertificateHostsPanelProps {
   onNavigateToHost: (hostType: string, hostId: number) => void
 }
 
-const CertificateHostsPanel: React.FC<CertificateHostsPanelProps> = ({
+const CertificateHostsPanel = ({
   certificate,
   onNavigateToHost,
-}) => {
+}: CertificateHostsPanelProps) => {
   const totalHosts = 
     (certificate.proxy_hosts?.length || 0) +
     (certificate.redirection_hosts?.length || 0) +

--- a/src/components/features/certificates/CertificateInfoPanel.tsx
+++ b/src/components/features/certificates/CertificateInfoPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Box,
@@ -28,12 +27,12 @@ interface CertificateInfoPanelProps {
   onCopyToClipboard: (text: string, label?: string) => void
 }
 
-const CertificateInfoPanel: React.FC<CertificateInfoPanelProps> = ({
+const CertificateInfoPanel = ({
   certificate,
   expandedSections: _expandedSections,
   onToggleSection: _onToggleSection,
   onCopyToClipboard,
-}) => {
+}: CertificateInfoPanelProps) => {
   const getDaysUntilExpiry = (expiresOn: string | null) => {
     if (!expiresOn) return null
     const expiryDate = new Date(expiresOn)

--- a/src/components/features/proxy-hosts/ProxyHostAccessPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostAccessPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Box,
@@ -30,12 +29,12 @@ interface ProxyHostAccessPanelProps {
   onNavigateToFullAccessList: () => void
 }
 
-const ProxyHostAccessPanel: React.FC<ProxyHostAccessPanelProps> = ({
+const ProxyHostAccessPanel = ({
   host,
   fullAccessList,
   loadingAccessList,
   onNavigateToFullAccessList,
-}) => {
+}: ProxyHostAccessPanelProps) => {
   if (!host.access_list) {
     return null
   }

--- a/src/components/features/proxy-hosts/ProxyHostActions.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostActions.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Button } from '@mui/material'
 import { Edit as EditIcon } from '@mui/icons-material'
 import { ProxyHost } from '../../../api/proxyHosts'
@@ -10,11 +9,11 @@ interface ProxyHostActionsProps {
   onEdit?: (host: ProxyHost) => void
 }
 
-const ProxyHostActions: React.FC<ProxyHostActionsProps> = ({
+const ProxyHostActions = ({
   host,
   onClose,
   onEdit,
-}) => {
+}: ProxyHostActionsProps) => {
   return (
     <>
       <Button onClick={onClose}>Close</Button>

--- a/src/components/features/proxy-hosts/ProxyHostAdvancedPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostAdvancedPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Paper,
@@ -10,9 +9,9 @@ interface ProxyHostAdvancedPanelProps {
   host: ProxyHost
 }
 
-const ProxyHostAdvancedPanel: React.FC<ProxyHostAdvancedPanelProps> = ({
+const ProxyHostAdvancedPanel = ({
   host,
-}) => {
+}: ProxyHostAdvancedPanelProps) => {
   return (
     <>
       {host.advanced_config ? (

--- a/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
@@ -26,12 +26,12 @@ interface ProxyHostConnectionsPanelProps {
   onEditRedirection: (redirectionId: number) => void
 }
 
-const ProxyHostConnectionsPanel: React.FC<ProxyHostConnectionsPanelProps> = ({
+const ProxyHostConnectionsPanel = ({
   linkedRedirections,
   loadingConnections,
   onNavigateToRedirection,
   onEditRedirection,
-}) => {
+}: ProxyHostConnectionsPanelProps) => {
   return (
     <Box>
       <Box display="flex" alignItems="center" gap={1} mb={3}>

--- a/src/components/features/proxy-hosts/ProxyHostInfoPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostInfoPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Box,
@@ -42,14 +41,14 @@ interface ProxyHostInfoPanelProps {
   onNavigateToAccess: () => void
 }
 
-const ProxyHostInfoPanel: React.FC<ProxyHostInfoPanelProps> = ({
+const ProxyHostInfoPanel = ({
   host,
   expandedSections,
   copiedText: _copiedText,
   onToggleSection,
   onCopyToClipboard,
   onNavigateToAccess,
-}) => {
+}: ProxyHostInfoPanelProps) => {
   const formatDate = (dateString: string | null) => {
     if (!dateString) return 'N/A'
     return new Date(dateString).toLocaleDateString('en-US', {

--- a/src/components/features/proxy-hosts/ProxyHostSSLPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostSSLPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Typography,
   Box,
@@ -18,10 +17,10 @@ interface ProxyHostSSLPanelProps {
   onNavigateToCertificate: () => void
 }
 
-const ProxyHostSSLPanel: React.FC<ProxyHostSSLPanelProps> = ({
+const ProxyHostSSLPanel = ({
   host,
   onNavigateToCertificate,
-}) => {
+}: ProxyHostSSLPanelProps) => {
   return (
     <Grid container spacing={3}>
       {/* SSL Certificate Info */}

--- a/src/components/shared/ActionChip.tsx
+++ b/src/components/shared/ActionChip.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Chip, ChipProps } from '@mui/material'
 import {
   Add as AddIcon,
@@ -54,7 +53,7 @@ const getActionColor = (action: ActionType): 'primary' | 'secondary' | 'error' |
   }
 }
 
-const ActionChip: React.FC<ActionChipProps> = ({ action, label, sx, ...props }) => {
+const ActionChip = ({ action, label, sx, ...props }: ActionChipProps) => {
   return (
     <Chip
       size="small"

--- a/src/components/shared/OwnerDisplay.tsx
+++ b/src/components/shared/OwnerDisplay.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Box, Typography, Avatar, Tooltip } from '@mui/material'
 import { Person as PersonIcon } from '@mui/icons-material'
 import { Owner } from '../../types/common'
@@ -11,13 +10,13 @@ interface OwnerDisplayProps {
   showEmail?: boolean
 }
 
-const OwnerDisplay: React.FC<OwnerDisplayProps> = ({
+const OwnerDisplay = ({
   owner,
   userId,
   showAvatar = false,
   size = 'medium',
   showEmail = false
-}) => {
+}: OwnerDisplayProps) => {
   // If no owner object but userId is provided, show user ID
   if (!owner && userId) {
     return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect } from 'react'
+import { createContext, useContext, useEffect, type ReactNode } from 'react'
 import { useAuthStore } from '../stores/authStore'
 import type { StoreApi } from 'zustand'
 
@@ -9,7 +9,7 @@ export type AuthStore = ReturnType<typeof useAuthStore>
 const AuthStoreContext = createContext<StoreApi<AuthStore> | null>(null)
 
 // Provider component
-export const AuthStoreProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const AuthStoreProvider = ({ children }: { children: ReactNode }) => {
   // Get the store API from zustand
   const storeApi = (useAuthStore as any).api
   

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePermissions } from '../hooks/usePermissions'
 import { proxyHostsApi } from '../api/proxyHosts'
@@ -35,7 +35,7 @@ interface GlobalSearchProviderProps {
   children: ReactNode
 }
 
-export const GlobalSearchProvider: React.FC<GlobalSearchProviderProps> = ({ children }) => {
+export const GlobalSearchProvider = ({ children }: GlobalSearchProviderProps) => {
   const navigate = useNavigate()
   const { canView, canManage, isAdmin } = usePermissions()
   

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { ThemeProvider as MUIThemeProvider } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import { lightTheme, darkTheme } from '../theme/index'
@@ -26,7 +26,7 @@ interface ThemeProviderProps {
   children: ReactNode
 }
 
-export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const [mode, setMode] = useState<ThemeMode>(() => {
     // Check localStorage first
     const saved = localStorage.getItem(THEME_KEY)

--- a/src/pages/AccessLists.tsx
+++ b/src/pages/AccessLists.tsx
@@ -351,6 +351,7 @@ export default function AccessLists() {
 
   return (
     <Container maxWidth={false}>
+      <title>Access Lists - NPMDeck</title>
       <Box py={3}>
         {/* Header */}
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>

--- a/src/pages/AuditLog.tsx
+++ b/src/pages/AuditLog.tsx
@@ -413,6 +413,7 @@ const AuditLog = () => {
 
   return (
     <Container maxWidth={false}>
+      <title>Audit Log - NPMDeck</title>
       <Box py={3}>
         <Box mb={3}>
           <PageHeader

--- a/src/pages/Certificates.tsx
+++ b/src/pages/Certificates.tsx
@@ -441,6 +441,7 @@ const Certificates = () => {
 
   return (
     <Container maxWidth={false}>
+      <title>SSL Certificates - NPMDeck</title>
       <Box py={3}>
         {/* Header */}
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   Divider,
   List,
-  ListItem,
+  ListItemButton,
   ListItemIcon,
   ListItemText,
   ListItemSecondaryAction,
@@ -238,6 +238,7 @@ const Dashboard = () => {
 
   return (
     <Box>
+      <title>Dashboard - NPMDeck</title>
       <Grid container spacing={2}>
         {/* Quick Actions - Now at the top */}
         <Grid item xs={12}>
@@ -339,8 +340,7 @@ const Dashboard = () => {
                     return (
                       <React.Fragment key={cert.id}>
                         {index > 0 && <Divider />}
-                        <ListItem 
-                          button
+                        <ListItemButton
                           onClick={() => navigate(`/security/certificates/${cert.id}/view`)}
                         >
                           <ListItemIcon>
@@ -367,7 +367,7 @@ const Dashboard = () => {
                               variant="outlined"
                             />
                           </ListItemSecondaryAction>
-                        </ListItem>
+                        </ListItemButton>
                       </React.Fragment>
                     )
                   })}

--- a/src/pages/Forbidden.tsx
+++ b/src/pages/Forbidden.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { 
   Box, 
@@ -10,7 +9,7 @@ import {
 } from '@mui/material'
 import { Lock as LockIcon } from '@mui/icons-material'
 
-const Forbidden: React.FC = () => {
+const Forbidden = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const state = location.state as { 
@@ -33,6 +32,7 @@ const Forbidden: React.FC = () => {
 
   return (
     <Container maxWidth="sm">
+      <title>Access Denied - NPMDeck</title>
       <Box
         sx={{
           marginTop: 8,

--- a/src/pages/ImportExport.tsx
+++ b/src/pages/ImportExport.tsx
@@ -169,6 +169,7 @@ export default function ImportExport() {
 
   return (
     <Container maxWidth="lg">
+      <title>Import &amp; Export - NPMDeck</title>
       <Box py={3}>
         <Typography variant="h4" gutterBottom>
           Import / Export

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -70,6 +70,7 @@ const Login = () => {
 
   return (
     <Container component="main" maxWidth="xs">
+      <title>Login - NPMDeck</title>
       <Box
         sx={{
           marginTop: 8,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,8 +5,10 @@ const NotFound = () => {
   const navigate = useNavigate()
 
   return (
-    <Box textAlign="center" mt={8}>
-      <Typography variant="h1" color="error">404</Typography>
+    <>
+      <title>Page Not Found - NPMDeck</title>
+      <Box textAlign="center" mt={8}>
+        <Typography variant="h1" color="error">404</Typography>
       <Typography variant="h5" mt={2}>Page Not Found</Typography>
       <Button 
         variant="contained" 
@@ -15,7 +17,8 @@ const NotFound = () => {
       >
         Back to Dashboard
       </Button>
-    </Box>
+      </Box>
+    </>
   )
 }
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -585,6 +585,7 @@ const Settings = () => {
 
   return (
     <Box>
+      <title>Settings - NPMDeck</title>
       <Box mb={3}>
         <PageHeader
           icon={React.createElement(NAVIGATION_CONFIG.settings.icon, { sx: { color: NAVIGATION_CONFIG.settings.color } })}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -445,6 +445,7 @@ const Users = () => {
 
   return (
     <Container maxWidth={false}>
+      <title>Users - NPMDeck</title>
       <Box py={3}>
         <Box mb={3} display="flex" justifyContent="space-between" alignItems="center">
           <PageHeader


### PR DESCRIPTION
## Summary

Implements all improvements identified during the React 19 migration audit (#24).

- **Replace deprecated MUI props**: `BackdropProps` → `slotProps.backdrop`, `componentsProps` → `slotProps`, `ListItem button` → `ListItemButton`
- **Fix Vite env usage**: `process.env.NODE_ENV` → `import.meta.env.DEV` in ErrorBoundary
- **Add page titles**: React 19 document metadata (`<title>`) on all 14 pages for better browser tab UX
- **Implement `useOptimistic`**: Toggle operations (enable/disable) in ProxyHosts, Streams, DeadHosts, RedirectionHosts now provide instant UI feedback with automatic rollback on error
- **Migrate `React.FC`**: All 35 components migrated to regular function declarations
- **Fix DOM nesting**: SearchBar `<div>` inside `<p>` warning resolved using `component="span"`
- **Fix MUI Select warning**: DataTableToolbar filter default value changed from `'all'` to `''`

## Test plan

- [x] Verify browser tab titles update when navigating between pages
- [x] Test enable/disable toggles on Proxy Hosts, Streams, Dead Hosts, Redirection Hosts - should respond instantly
- [x] Verify BaseDialog backdrop blur still works
- [x] Verify SearchBar autocomplete popper positioning
- [x] Check console for warnings on /admin/audit-log and /security/access-lists
- [x] Run `pnpm run typecheck` (0 errors)
- [x] Run `pnpm run lint` (0 errors)
- [x] Run `pnpm run build` (success)

Closes #24