### PR TITLE
refactor: create BaseEntity type hierarchy (#44)

### DIFF
--- a/src/api/accessLists.ts
+++ b/src/api/accessLists.ts
@@ -1,33 +1,22 @@
 import api from './config'
-import { Owner } from '../types/common'
+import type { OwnedEntity, BaseEntity } from '../types/base'
 
-export interface AccessList {
-  id: number
-  created_on: string
-  modified_on: string
-  owner_user_id: number
+export interface AccessList extends OwnedEntity {
   name: string
   meta: Record<string, any>
   satisfy_any: boolean
   pass_auth: boolean
   // Relations
-  owner?: Owner
   items?: AccessListItem[]
   clients?: AccessListClient[]
 }
 
-export interface AccessListItem {
-  id: number
-  created_on: string
-  modified_on: string
+export interface AccessListItem extends BaseEntity {
   username: string
   password: string
 }
 
-export interface AccessListClient {
-  id: number
-  created_on: string
-  modified_on: string
+export interface AccessListClient extends BaseEntity {
   address: string
   directive: 'allow' | 'deny'
 }

--- a/src/api/certificates.ts
+++ b/src/api/certificates.ts
@@ -1,11 +1,7 @@
 import api from './config'
-import { Owner } from '../types/common'
+import type { OwnedEntity } from '../types/base'
 
-export interface Certificate {
-  id: number
-  created_on: string
-  modified_on: string
-  owner_user_id: number
+export interface Certificate extends OwnedEntity {
   provider: 'letsencrypt' | 'other'
   nice_name: string
   domain_names: string[]
@@ -19,8 +15,6 @@ export interface Certificate {
     propagation_seconds?: number
     certificate_id?: string
   }
-  // Relations
-  owner?: Owner
 }
 
 export interface CreateCertificate {

--- a/src/api/deadHosts.ts
+++ b/src/api/deadHosts.ts
@@ -1,30 +1,11 @@
 import api from './config'
+import type { HostEntity, NginxMeta, LetsEncryptMeta } from '../types/base'
+import type { Certificate } from './certificates'
 
-export interface DeadHost {
-  id: number
-  created_on: string
-  modified_on: string
-  owner_user_id: number
-  domain_names: string[]
-  certificate_id: number
-  ssl_forced: boolean
-  hsts_enabled: boolean
-  hsts_subdomains: boolean
-  http2_support: boolean
-  advanced_config: string
-  enabled: boolean
-  meta: {
-    nginx_online?: boolean
-    nginx_err?: string | null
-    letsencrypt_agree?: boolean
-    dns_challenge?: boolean
-    dns_provider?: string
-    dns_provider_credentials?: string
-    propagation_seconds?: number
-  }
+export interface DeadHost extends HostEntity {
+  meta: NginxMeta & LetsEncryptMeta
   // Expanded relations
-  certificate?: any
-  owner?: any
+  certificate?: Certificate
 }
 
 export interface CreateDeadHost {

--- a/src/api/proxyHosts.ts
+++ b/src/api/proxyHosts.ts
@@ -1,36 +1,19 @@
 import api from './config'
-import { Owner } from '../types/common'
+import type { HostEntity } from '../types/base'
 import { Certificate } from './certificates'
 import { AccessList } from './accessLists'
 
-export interface ProxyHost {
-  id: number
-  created_on: string
-  modified_on: string
-  owner_user_id: number
-  domain_names: string[]
+export interface ProxyHost extends HostEntity {
   forward_host: string
   forward_port: number
   access_list_id: number
-  certificate_id: number
-  ssl_forced: boolean
   caching_enabled: boolean
   block_exploits: boolean
-  advanced_config: string
-  meta: {
-    nginx_online?: boolean
-    nginx_err?: string | null
-  }
   allow_websocket_upgrade: boolean
-  http2_support: boolean
   forward_scheme: 'http' | 'https'
-  enabled: boolean
   locations: ProxyHostLocation[] | null
-  hsts_enabled: boolean
-  hsts_subdomains: boolean
   // Expanded relations
   certificate?: Certificate
-  owner?: Owner
   access_list?: AccessList
 }
 

--- a/src/api/redirectionHosts.ts
+++ b/src/api/redirectionHosts.ts
@@ -1,51 +1,18 @@
 import api from './config'
+import type { HostEntity, NginxMeta, LetsEncryptMeta } from '../types/base'
+import type { Certificate } from './certificates'
+import type { AccessList } from './accessLists'
 
-// Interfaces
-export interface RedirectionHost {
-  id: number
-  created_on: string
-  modified_on: string
-  domain_names: string[]
+export interface RedirectionHost extends HostEntity {
   forward_http_code: number
   forward_scheme: string
   forward_domain_name: string
   preserve_path: boolean
-  certificate_id: number
-  ssl_forced: boolean
-  hsts_enabled: boolean
-  hsts_subdomains: boolean
   block_exploits: boolean
-  http2_support: boolean
-  advanced_config: string
-  enabled: boolean
-  meta: {
-    nginx_online?: boolean
-    nginx_err?: string
-    dns_challenge?: boolean
-    dns_provider?: string
-    dns_provider_credentials?: string
-    propagation_seconds?: number
-    letsencrypt_email?: string
-    letsencrypt_agree?: boolean
-  }
-  // Expansions
-  owner?: {
-    id: number
-    email: string
-    name: string
-  }
-  certificate?: {
-    id: number
-    provider: string
-    nice_name: string
-    domain_names: string[]
-    expires_on: string | null
-    meta: any
-  }
-  access_list?: {
-    id: number
-    name: string
-  }
+  meta: NginxMeta & LetsEncryptMeta
+  // Expanded relations
+  certificate?: Certificate
+  access_list?: AccessList
 }
 
 export interface CreateRedirectionHost {

--- a/src/api/streams.ts
+++ b/src/api/streams.ts
@@ -1,30 +1,17 @@
 import api from './config'
+import type { ToggleableEntity, NginxMeta, LetsEncryptMeta } from '../types/base'
+import type { Certificate } from './certificates'
 
-export interface Stream {
-  id: number
-  created_on: string
-  modified_on: string
-  owner_user_id: number
+export interface Stream extends ToggleableEntity {
   incoming_port: number
   forwarding_host: string
   forwarding_port: number
   tcp_forwarding: boolean
   udp_forwarding: boolean
-  enabled: boolean
   certificate_id: number
-  meta: {
-    nginx_online?: boolean
-    nginx_err?: string | null
-    letsencrypt_email?: string
-    letsencrypt_agree?: boolean
-    dns_challenge?: boolean
-    dns_provider?: string
-    dns_provider_credentials?: string
-    propagation_seconds?: number
-  }
+  meta: NginxMeta & LetsEncryptMeta
   // Expanded relations
-  owner?: any
-  certificate?: any
+  certificate?: Certificate
 }
 
 export interface CreateStream {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,7 +1,7 @@
 import api from './config'
+import type { BaseEntity } from '../types/base'
 
-export interface User {
-  id: number
+export interface User extends BaseEntity {
   email: string
   name: string
   nickname: string
@@ -17,8 +17,6 @@ export interface User {
     access_lists?: 'hidden' | 'view' | 'manage'
     certificates?: 'hidden' | 'view' | 'manage'
   }
-  created_on: string
-  modified_on: string
   last_login?: string
 }
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,0 +1,59 @@
+/**
+ * Base entity type hierarchy for API entities.
+ * Eliminates field duplication across entity interfaces.
+ */
+
+/** Common owner type used across entities */
+export interface Owner {
+  id: number
+  email: string
+  name: string
+  nickname: string
+}
+
+/** Absolute minimal base: fields present in ALL entities */
+export interface BaseEntity {
+  id: number
+  created_on: string
+  modified_on: string
+}
+
+/** Base for entities with owner (all except User) */
+export interface OwnedEntity extends BaseEntity {
+  owner_user_id: number
+  owner?: Owner
+}
+
+/** Nginx meta object for host/stream entities */
+export interface NginxMeta {
+  nginx_online?: boolean
+  nginx_err?: string | null
+}
+
+/** Let's Encrypt meta fields shared across entities */
+export interface LetsEncryptMeta {
+  letsencrypt_email?: string
+  letsencrypt_agree?: boolean
+  dns_challenge?: boolean
+  dns_provider?: string
+  dns_provider_credentials?: string
+  propagation_seconds?: number
+}
+
+/** Base for all host entities (ProxyHost, DeadHost, RedirectionHost) */
+export interface HostEntity extends OwnedEntity {
+  domain_names: string[]
+  certificate_id: number
+  ssl_forced: boolean
+  hsts_enabled: boolean
+  hsts_subdomains: boolean
+  http2_support: boolean
+  advanced_config: string
+  enabled: boolean
+  meta: NginxMeta
+}
+
+/** Toggleable entity (has enable/disable) */
+export interface ToggleableEntity extends OwnedEntity {
+  enabled: boolean
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,9 +1,9 @@
-import { User } from '../api/users'
+import type { Owner } from './base'
 import { Certificate } from '../api/certificates'
 import { AccessList } from '../api/accessLists'
 
-// Common owner type used across entities
-export type Owner = Pick<User, 'id' | 'email' | 'name' | 'nickname'>
+// Re-export Owner from base types for backward compatibility
+export type { Owner }
 
 // Extended certificate type with proper relations
 export interface CertificateWithRelations extends Omit<Certificate, 'owner'> {

--- a/src/utils/statusUtils.tsx
+++ b/src/utils/statusUtils.tsx
@@ -7,10 +7,12 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import CancelIcon from '@mui/icons-material/Cancel'
 import ErrorIcon from '@mui/icons-material/Error'
 
+import type { NginxMeta } from '../types/base'
+
 /** Entity shape required for status utilities */
 interface StatusEntity {
   enabled: boolean
-  meta: { nginx_online?: boolean; nginx_err?: string | null }
+  meta: NginxMeta
 }
 
 /**


### PR DESCRIPTION
## Summary

- Create `src/types/base.ts` with `BaseEntity`, `OwnedEntity`, `HostEntity`, `ToggleableEntity`, `NginxMeta`, and `LetsEncryptMeta` interfaces
- Refactor all 7 API entity interfaces to extend base types, eliminating ~40 duplicate field definitions
- Fix `any` types in DeadHost/Stream relations (certificate, owner) with proper typed imports
- Replace inline type definitions in RedirectionHost with shared types
- Add missing `owner_user_id` to RedirectionHost via HostEntity inheritance

## Test plan

- [x] `pnpm run typecheck` passes (0 errors)
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [x] Verify all entity pages render correctly (ProxyHosts, DeadHosts, Streams, RedirectionHosts, Certificates, AccessLists, Users)
- [x] Verify CRUD operations still work for each entity type

Closes #44