### PR TITLE
fix: eliminate all any types in hooks (#47)

### DIFF
--- a/src/components/features/certificates/CertificateDrawer.tsx
+++ b/src/components/features/certificates/CertificateDrawer.tsx
@@ -100,7 +100,7 @@ export default function CertificateDrawer({
     },
     fields: {
       provider: {
-        required: true, initialValue: undefined,
+        required: true, initialValue: 'letsencrypt',
       },
       niceName: {
         initialValue: '',

--- a/src/hooks/useDashboardStats.ts
+++ b/src/hooks/useDashboardStats.ts
@@ -1,12 +1,18 @@
 import { useState, useEffect } from 'react'
 import { proxyHostsApi } from '../api/proxyHosts'
+import type { ProxyHost } from '../api/proxyHosts'
 import { redirectionHostsApi } from '../api/redirectionHosts'
+import type { RedirectionHost } from '../api/redirectionHosts'
 import { deadHostsApi } from '../api/deadHosts'
+import type { DeadHost } from '../api/deadHosts'
 import { streamsApi } from '../api/streams'
+import type { Stream } from '../api/streams'
 import { certificatesApi, Certificate } from '../api/certificates'
 import { accessListsApi } from '../api/accessLists'
+import type { AccessList } from '../api/accessLists'
 import { usePermissions } from './usePermissions'
 import { getDaysUntilExpiry } from '../utils/dateUtils'
+import logger from '../utils/logger'
 
 export interface DashboardStats {
   proxyHosts: {
@@ -73,34 +79,34 @@ export const useDashboardStats = () => {
 
         const [proxyHosts, redirectionHosts, deadHosts, streams, certificates, accessLists] = results.map(
           result => result.status === 'fulfilled' ? result.value : []
-        ) as [any[], any[], any[], any[], Certificate[], any[]]
+        ) as [ProxyHost[], RedirectionHost[], DeadHost[], Stream[], Certificate[], AccessList[]]
 
         // Process proxy hosts
         const proxyStats = {
           total: proxyHosts.length,
-          active: proxyHosts.filter((h: any) => h.enabled).length,
-          inactive: proxyHosts.filter((h: any) => !h.enabled).length
+          active: proxyHosts.filter(h => h.enabled).length,
+          inactive: proxyHosts.filter(h => !h.enabled).length
         }
 
         // Process redirection hosts
         const redirectionStats = {
           total: redirectionHosts.length,
-          active: redirectionHosts.filter((h: any) => h.enabled).length,
-          inactive: redirectionHosts.filter((h: any) => !h.enabled).length
+          active: redirectionHosts.filter(h => h.enabled).length,
+          inactive: redirectionHosts.filter(h => !h.enabled).length
         }
 
         // Process dead hosts
         const deadStats = {
           total: deadHosts.length,
-          active: deadHosts.filter((h: any) => h.enabled).length,
-          inactive: deadHosts.filter((h: any) => !h.enabled).length
+          active: deadHosts.filter(h => h.enabled).length,
+          inactive: deadHosts.filter(h => !h.enabled).length
         }
 
         // Process streams
         const streamStats = {
           total: streams.length,
-          active: streams.filter((s: any) => s.enabled).length,
-          inactive: streams.filter((s: any) => !s.enabled).length
+          active: streams.filter(s => s.enabled).length,
+          inactive: streams.filter(s => !s.enabled).length
         }
 
         // Process certificates
@@ -149,7 +155,7 @@ export const useDashboardStats = () => {
           error: null
         })
       } catch (error) {
-        console.error('Failed to fetch dashboard stats:', error)
+        logger.error('Failed to fetch dashboard stats:', error)
         setStats(prev => ({
           ...prev,
           loading: false,


### PR DESCRIPTION
## Summary
- Replace 16 `any` types across 3 hook files (`useDashboardStats`, `useDrawerForm`, `useAuthInterceptors`) with proper TypeScript types
- Migrate 2 `console.error` calls to project logger utility
- Fix `CertificateDrawer` initialValue bug uncovered by improved `FieldConfig` typing

## Changes
- **useDashboardStats.ts**: Proper entity types in `Promise.allSettled` tuple cast (ProxyHost, RedirectionHost, DeadHost, Stream, AccessList), inferred filter callbacks, logger migration
- **useDrawerForm.ts**: Mapped type constraint `{ [K in keyof T]: T[K] }` for interface compatibility, `FieldConfig<T = unknown>`, `T[keyof T]` for value params, logger migration
- **useAuthInterceptors.ts**: `RetryableAxiosConfig` type alias replacing `as any` casts, consistent with `api/config.ts` pattern
- **CertificateDrawer.tsx**: `initialValue: undefined` → `'letsencrypt'` (type error surfaced by improved generics)

## Validation
- `pnpm run typecheck`: 0 errors
- `pnpm run lint`: 0 errors (129 pre-existing warnings, reduced from 151)
- `grep any src/hooks/`: 0 TypeScript any types remaining

## Test plan
- [x] Verify dashboard stats load correctly
- [x] Test form creation/editing in all drawers (ProxyHost, Certificate, Stream, etc.)
- [x] Test auth token refresh flow (session expiry handling)
- [x] Verify certificate drawer defaults to Let's Encrypt provider

Closes #47