### PR TITLE
fix: add missing return type annotations (#50)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -37,7 +37,7 @@ export const authApi = {
   },
 
   // Logout (client-side only)
-  logout: () => {
+  logout: (): void => {
     localStorage.removeItem(STORAGE_KEYS.TOKEN)
     localStorage.removeItem(STORAGE_KEYS.USER)
   }

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -15,7 +15,7 @@ let failedQueue: Array<{
 }> = []
 
 // Process the queue when token is refreshed
-const processQueue = (error: unknown, token: string | null = null) => {
+const processQueue = (error: unknown, token: string | null = null): void => {
   failedQueue.forEach(prom => {
     if (error) {
       prom.reject(error)

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ export default function ConfirmDialog({
   confirmColor = 'primary',
   loading = false,
 }: ConfirmDialogProps) {
-  const handleConfirm = () => {
+  const handleConfirm = (): void => {
     onConfirm()
     // Don't close automatically when loading
     if (!loading) {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -71,14 +71,14 @@ const ToastContext = createContext<ToastContextValue | undefined>(undefined);
 /**
  * Slide transition for toast
  */
-function _SlideTransition(props: SlideProps) {
+function _SlideTransition(props: SlideProps): React.JSX.Element {
   return <Slide {...props} direction="down" />;
 }
 
 /**
  * Get entity icon
  */
-function getEntityIcon(entityType: EntityType) {
+function getEntityIcon(entityType: EntityType): React.ElementType {
   const icons: Record<EntityType, React.ElementType> = {
     'proxy-host': ProxyIcon,
     'redirection-host': RedirectionIcon,
@@ -96,7 +96,7 @@ function getEntityIcon(entityType: EntityType) {
 /**
  * Get action icon
  */
-function getActionIcon(action?: ActionType) {
+function getActionIcon(action?: ActionType): React.ElementType | null {
   if (!action) return null;
   
   const icons: Record<ActionType, React.ElementType> = {
@@ -475,7 +475,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 /**
  * Hook to use toast functionality
  */
-export function useToast() {
+export function useToast(): ToastContextValue {
   const context = useContext(ToastContext);
   if (!context) {
     throw new Error('useToast must be used within a ToastProvider');

--- a/src/hooks/useAuthInterceptors.ts
+++ b/src/hooks/useAuthInterceptors.ts
@@ -7,7 +7,7 @@ import api from '../api/config'
 
 type RetryableAxiosConfig = InternalAxiosRequestConfig & { _retry?: boolean }
 
-export const useAuthInterceptors = () => {
+export const useAuthInterceptors = (): void => {
   const { showToast, showError, showInfo } = useToast()
   const authStore = useAuthStore()
 

--- a/src/hooks/useDashboardStats.ts
+++ b/src/hooks/useDashboardStats.ts
@@ -49,7 +49,7 @@ export interface DashboardStats {
   error: string | null
 }
 
-export const useDashboardStats = () => {
+export const useDashboardStats = (): DashboardStats => {
   const { canView } = usePermissions()
   const [stats, setStats] = useState<DashboardStats>({
     proxyHosts: { total: 0, active: 0, inactive: 0 },

--- a/src/hooks/useFilteredData.ts
+++ b/src/hooks/useFilteredData.ts
@@ -25,11 +25,18 @@ export function useFilteredData<T extends HasOwnerId>(
   }, [data, user, shouldFilterByUser])
 }
 
+export interface FilteredInfo {
+  isFiltered: boolean
+  hiddenCount: number
+  totalCount: number
+  visibleCount: number
+}
+
 // Hook for displaying filtered count info
 export function useFilteredInfo<T extends HasOwnerId>(
   data: T[],
   filteredData: T[]
-) {
+): FilteredInfo {
   const { shouldFilterByUser } = useAuthStore()
 
   return useMemo(() => {

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,8 +1,26 @@
 import { useMemo } from 'react'
 import { useAuthStore } from '../stores/authStore'
+import { User } from '../api/users'
 import { Resource, PermissionLevel } from '../types/permissions'
 
-export const usePermissions = () => {
+export interface UsePermissionsReturn {
+  user: User | null
+  hasPermission: (resource: Resource, level: PermissionLevel) => boolean
+  canView: (resource: Resource) => boolean
+  canManage: (resource: Resource) => boolean
+  canAccess: (resource: Resource, action: 'view' | 'create' | 'edit' | 'delete') => boolean
+  isAdmin: boolean
+  hasAnyPermission: (level?: PermissionLevel) => boolean
+  getVisibleResources: () => Resource[]
+  shouldFilterByUser: boolean
+  canCreateResource: (resource: Resource) => boolean
+  canEditResource: (resource: Resource) => boolean
+  canDeleteResource: (resource: Resource) => boolean
+  hasAnyOfPermissions: (checks: Array<{ resource: Resource; level: PermissionLevel }>) => boolean
+  hasAllOfPermissions: (checks: Array<{ resource: Resource; level: PermissionLevel }>) => boolean
+}
+
+export const usePermissions = (): UsePermissionsReturn => {
   const {
     user,
     hasPermission,
@@ -75,13 +93,13 @@ export const usePermissions = () => {
 }
 
 // Type-safe permission check helper
-export const usePermissionCheck = (resource: Resource, level: PermissionLevel = 'view') => {
+export const usePermissionCheck = (resource: Resource, level: PermissionLevel = 'view'): boolean => {
   const { hasPermission } = usePermissions()
   return hasPermission(resource, level)
 }
 
 // Type-safe action permission check helper
-export const useActionPermission = (resource: Resource, action: 'view' | 'create' | 'edit' | 'delete') => {
+export const useActionPermission = (resource: Resource, action: 'view' | 'create' | 'edit' | 'delete'): boolean => {
   const { canAccess } = usePermissions()
   return canAccess(resource, action)
 }

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,11 +1,38 @@
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 
+export interface UseResponsiveReturn {
+  // Basic responsive states
+  isMobile: boolean
+  isTablet: boolean
+  isDesktop: boolean
+
+  // Table-specific states
+  isMobileTable: boolean
+  isCompactTable: boolean
+  isFullTable: boolean
+  isExtraSmall: boolean
+
+  // Utility functions
+  getCurrentBreakpoint: () => 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  isBelow: (breakpoint: 'sm' | 'md' | 'lg' | 'xl') => boolean
+  isAbove: (breakpoint: 'xs' | 'sm' | 'md' | 'lg') => boolean
+
+  // Raw breakpoint values for custom logic
+  breakpoints: {
+    xs: number
+    sm: number
+    md: number
+    lg: number
+    xl: number
+  }
+}
+
 /**
  * Generic responsive hook for consistent breakpoint handling
  * Uses Material-UI breakpoints for responsive behavior
  */
-export function useResponsive() {
+export function useResponsive(): UseResponsiveReturn {
   const theme = useTheme()
   
   // Standard breakpoints

--- a/src/services/importExport.ts
+++ b/src/services/importExport.ts
@@ -90,7 +90,7 @@ export class ImportExportService {
   }
 
   // Download export as file
-  static downloadExport(exportData: ExportData, filename?: string) {
+  static downloadExport(exportData: ExportData, filename?: string): void {
     const jsonString = JSON.stringify(exportData, null, 2)
     const blob = new Blob([jsonString], { type: 'application/json' })
     const url = URL.createObjectURL(blob)

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -73,7 +73,7 @@ const loadTokenStack = (): TokenInfo[] => {
 }
 
 // Helper to save token stack to localStorage
-const saveTokenStack = (stack: TokenInfo[]) => {
+const saveTokenStack = (stack: TokenInfo[]): void => {
   localStorage.setItem(STORAGE_KEYS.TOKEN_STACK, JSON.stringify(stack))
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -13,7 +13,7 @@ interface Logger {
   table: (data: Record<string, unknown> | unknown[]) => void
 }
 
-const noop = () => {}
+const noop = (): void => {}
 
 const logger: Logger = {
   log: isDevelopment ? console.log.bind(console) : noop,


### PR DESCRIPTION
## Summary

- Define `UsePermissionsReturn` interface for `usePermissions` hook return type
- Define `UseResponsiveReturn` interface for `useResponsive` hook return type
- Define `FilteredInfo` interface for `useFilteredInfo` hook return type
- Add explicit return types to `useDashboardStats`, `useAuthInterceptors`, `usePermissionCheck`, `useActionPermission`
- Annotate ToastContext helpers: `getEntityIcon`, `getActionIcon`, `_SlideTransition`, `useToast`
- Annotate utility/store functions: `noop`, `processQueue`, `saveTokenStack`, `logout`, `downloadExport`, `handleConfirm`

12 files changed, +69 / -17 lines. No functional changes.

Closes #50

## Test plan

- [x] Verify `pnpm run typecheck` passes (0 errors)
- [x] Verify `pnpm run lint` passes (0 errors, 128 warnings unchanged)
- [x] Verify no runtime behavior changes