### PR TITLE
fix: replace console.error with project logger (#51)

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react'
 import { Box, Button, Container, Paper, Typography, Stack, Alert } from '@mui/material'
 import { Refresh as RefreshIcon, ErrorOutline as ErrorIcon } from '@mui/icons-material'
+import logger from '../utils/logger'
 
 interface Props {
   children: ReactNode
@@ -24,7 +25,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Error caught by boundary:', error, errorInfo)
+    logger.error('Error caught by boundary:', error, errorInfo)
     this.setState({ errorInfo })
   }
 

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/icons-material'
 import { ImportExportService, ExportType } from '../services/importExport'
 import { NAVIGATION_COLORS } from '../constants/navigation'
+import logger from '../utils/logger'
 
 interface ExportDialogProps {
   open: boolean
@@ -64,7 +65,7 @@ export default function ExportDialog({
       ImportExportService.downloadExport(exportData, filename || defaultFilename)
       onClose()
     } catch (error) {
-      console.error('Export failed:', error)
+      logger.error('Export failed:', error)
     }
   }
 

--- a/src/components/ProxyHostDetailsDialog.tsx
+++ b/src/components/ProxyHostDetailsDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { ProxyHost } from '../api/proxyHosts'
 import { redirectionHostsApi, RedirectionHost } from '../api/redirectionHosts'
 import { AccessList, accessListsApi } from '../api/accessLists'
+import logger from '../utils/logger'
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard'
 // import ExportDialog from './ExportDialog'
 import { usePermissions } from '../hooks/usePermissions'
@@ -117,7 +118,7 @@ const ProxyHostDetailsDialog = ({
       
       setLinkedRedirections(linkedRedirects)
     } catch (error) {
-      console.error('Failed to load connections:', error)
+      logger.error('Failed to load connections:', error)
     } finally {
       setLoadingConnections(false)
     }
@@ -131,7 +132,7 @@ const ProxyHostDetailsDialog = ({
       const data = await accessListsApi.getById(host.access_list.id, ['items', 'clients', 'owner'])
       setFullAccessList(data)
     } catch (error) {
-      console.error('Failed to load access list details:', error)
+      logger.error('Failed to load access list details:', error)
     } finally {
       setLoadingAccessList(false)
     }

--- a/src/components/features/dead-hosts/DeadHostDrawer.tsx
+++ b/src/components/features/dead-hosts/DeadHostDrawer.tsx
@@ -25,6 +25,7 @@ import DomainInput from '../../DomainInput'
 import { useDrawerForm } from '../../../hooks/useDrawerForm'
 import { useToast } from '../../../contexts/ToastContext'
 import { NAVIGATION_CONFIG } from '../../../constants/navigation'
+import logger from '../../../utils/logger'
 
 interface DeadHostDrawerProps {
   open: boolean
@@ -147,7 +148,7 @@ export default function DeadHostDrawer({ open, onClose, host, onSave }: DeadHost
       const certs = await certificatesApi.getAll()
       setCertificates(certs)
     } catch (err: unknown) {
-      console.error('Failed to load certificates:', err)
+      logger.error('Failed to load certificates:', err)
     } finally {
       setLoadingCertificates(false)
     }

--- a/src/contexts/GlobalSearchContext.tsx
+++ b/src/contexts/GlobalSearchContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
+import logger from '../utils/logger'
 import { TIMING } from '../constants/timing'
 import { usePermissions } from '../hooks/usePermissions'
 import { proxyHostsApi } from '../api/proxyHosts'
@@ -88,7 +89,7 @@ export const GlobalSearchProvider = ({ children }: GlobalSearchProviderProps) =>
         const data = await loader()
         return data
       } catch (error) {
-        console.error(`Failed to load ${type}:`, error)
+        logger.error(`Failed to load ${type}:`, error)
         return []
       } finally {
         setSearchState(prev => ({

--- a/src/pages/DeadHosts.tsx
+++ b/src/pages/DeadHosts.tsx
@@ -41,6 +41,7 @@ import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/R
 import { Filter, FilterValue, BulkAction } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { getStatusIcon } from '../utils/statusUtils'
+import logger from '../utils/logger'
 
 export default function DeadHosts() {
   const { id } = useParams<{ id?: string }>()
@@ -104,7 +105,7 @@ export default function DeadHosts() {
         }
       } else if (hosts.length > 0) {
         // Host not found after loading (but other hosts exist)
-        console.error(`404 host with id ${id} not found`)
+        logger.error(`404 host with id ${id} not found`)
         navigate('/hosts/404')
       }
       // If hosts.length === 0, we'll wait for hosts to load
@@ -184,7 +185,7 @@ export default function DeadHosts() {
       setHostToDelete(null)
     } catch (err: unknown) {
       showError('dead-host', 'delete', err instanceof Error ? err.message : 'Unknown error', hostToDelete.domain_names[0], hostToDelete.id)
-      console.error('Failed to delete 404 host:', err)
+      logger.error('Failed to delete 404 host:', err)
     }
   }
 

--- a/src/pages/ImportExport.tsx
+++ b/src/pages/ImportExport.tsx
@@ -27,6 +27,7 @@ import { deadHostsApi } from '../api/deadHosts'
 import { streamsApi } from '../api/streams'
 import { certificatesApi } from '../api/certificates'
 import { accessListsApi } from '../api/accessLists'
+import logger from '../utils/logger'
 
 export default function ImportExport() {
   const [importDialogOpen, setImportDialogOpen] = useState(false)
@@ -64,7 +65,7 @@ export default function ImportExport() {
       setExportTypeName('All Configurations')
       setExportDialogOpen(true)
     } catch (error) {
-      console.error('Failed to fetch data for export:', error)
+      logger.error('Failed to fetch data for export:', error)
     } finally {
       setLoading(false)
     }
@@ -115,7 +116,7 @@ export default function ImportExport() {
       setExportTypeName(typeName)
       setExportDialogOpen(true)
     } catch (error) {
-      console.error('Failed to fetch data for export:', error)
+      logger.error('Failed to fetch data for export:', error)
     } finally {
       setLoading(false)
     }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,6 +13,7 @@ import {
 import { useAuthStore } from '../stores/authStore'
 import { getErrorMessage } from '../types/common'
 import UserProfileModal from '../components/UserProfileModal'
+import logger from '../utils/logger'
 
 const Login = () => {
   const navigate = useNavigate()
@@ -62,7 +63,7 @@ const Login = () => {
       }
     } catch (error: unknown) {
       // Error is handled in the store, but also set local error as fallback
-      console.error('Login error:', error)
+      logger.error('Login error:', error)
       const errorMessage = getErrorMessage(error)
       setLocalError(errorMessage)
     }

--- a/src/pages/ProxyHosts.tsx
+++ b/src/pages/ProxyHosts.tsx
@@ -44,6 +44,7 @@ import { Filter, FilterValue, BulkAction, GroupConfig } from '../components/Data
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { extractBaseDomain } from '../utils/domainUtils'
 import { getStatusIcon } from '../utils/statusUtils'
+import logger from '../utils/logger'
 
 export default function ProxyHosts() {
   const { id } = useParams<{ id?: string }>()
@@ -107,7 +108,7 @@ export default function ProxyHosts() {
         }
       } else if (hosts.length > 0) {
         // Host not found after loading (but other hosts exist)
-        console.error(`Proxy host with id ${id} not found`)
+        logger.error(`Proxy host with id ${id} not found`)
         navigate('/hosts/proxy')
       }
       // If hosts.length === 0, we'll wait for hosts to load
@@ -203,7 +204,7 @@ export default function ProxyHosts() {
       setHostToDelete(null)
     } catch (err: unknown) {
       showError('proxy-host', 'delete', err instanceof Error ? err.message : 'Unknown error', hostToDelete.domain_names[0], hostToDelete.id)
-      console.error('Failed to delete host:', err)
+      logger.error('Failed to delete host:', err)
     }
   }
 

--- a/src/pages/RedirectionHosts.tsx
+++ b/src/pages/RedirectionHosts.tsx
@@ -46,6 +46,7 @@ import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { extractBaseDomain } from '../utils/domainUtils'
 import { getHttpStatusLabel } from '../utils/httpUtils'
 import { getStatusIcon } from '../utils/statusUtils'
+import logger from '../utils/logger'
 
 export default function RedirectionHosts() {
   const { id } = useParams<{ id?: string }>()
@@ -109,7 +110,7 @@ export default function RedirectionHosts() {
         }
       } else if (hosts.length > 0) {
         // Host not found after loading (but other hosts exist)
-        console.error(`Redirection host with id ${id} not found`)
+        logger.error(`Redirection host with id ${id} not found`)
         navigate('/hosts/redirection')
       }
       // If hosts.length === 0, we'll wait for hosts to load
@@ -203,7 +204,7 @@ export default function RedirectionHosts() {
       setHostToDelete(null)
     } catch (err: unknown) {
       showError('redirection-host', 'delete', err instanceof Error ? err.message : 'Unknown error', hostToDelete.domain_names[0], hostToDelete.id)
-      console.error('Failed to delete redirection host:', err)
+      logger.error('Failed to delete redirection host:', err)
     }
   }
 

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -40,6 +40,7 @@ import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/R
 import { Filter, FilterValue, BulkAction } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { getStatusIcon } from '../utils/statusUtils'
+import logger from '../utils/logger'
 
 export default function Streams() {
   const navigate = useNavigate()
@@ -132,7 +133,7 @@ export default function Streams() {
     } catch (err: unknown) {
       const streamName = streamToDelete ? `${streamToDelete.incoming_port}/${streamToDelete.tcp_forwarding ? 'TCP' : ''}${streamToDelete.udp_forwarding ? 'UDP' : ''}` : undefined
       showError('stream', 'delete', err instanceof Error ? err.message : 'Unknown error', streamName, streamToDelete?.id)
-      console.error('Failed to delete stream:', err)
+      logger.error('Failed to delete stream:', err)
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace all 16 direct `console.error()` calls across 11 files with `logger.error()` from `src/utils/logger.ts`
- Add logger import to all affected files (components, pages, contexts)
- Zero direct `console.*` calls remaining in `src/` (except `logger.ts` itself, which is ESLint-exempted)

## Files Changed (11)
**Pages:** ProxyHosts, DeadHosts, Streams, RedirectionHosts, ImportExport, Login
**Components:** ErrorBoundary, ExportDialog, ProxyHostDetailsDialog, DeadHostDrawer
**Contexts:** GlobalSearchContext

## Verification
- `pnpm run typecheck`: 0 errors
- `pnpm run lint`: 0 errors (112 pre-existing warnings)
- `no-console` ESLint rule active (`warn`) with `logger.ts` exempted

Closes #51