### PR TITLE
perf: add missing memoization with useMemo/useCallback (#52)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useTransition } from 'react'
+import React, { useState, useTransition, useMemo, useCallback } from 'react'
 import { Outlet, useNavigate, useLocation } from 'react-router-dom'
 import {
   AppBar,
@@ -58,78 +58,76 @@ const Layout = () => {
   const [securityOpen, setSecurityOpen] = useState(false)
   const [adminOpen, setAdminOpen] = useState(false)
   
-  const handleNavigate = (path: string) => {
+  const handleNavigate = useCallback((path: string) => {
     startTransition(() => {
       navigate(path)
     })
-  }
+  }, [navigate])
 
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen)
-  }
+  const handleDrawerToggle = useCallback(() => {
+    setMobileOpen(prev => !prev)
+  }, [])
 
   // Auto-close mobile drawer after navigation
-  const handleMobileNavigate = (path: string) => {
+  const handleMobileNavigate = useCallback((path: string) => {
     handleNavigate(path)
     // Close mobile drawer after navigation click
-    if (mobileOpen) {
-      setMobileOpen(false)
-    }
-  }
+    setMobileOpen(false)
+  }, [handleNavigate])
 
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+  const handleMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
-  }
+  }, [])
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setAnchorEl(null)
-  }
+  }, [])
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     startTransition(() => {
       logout()
       navigate('/login')
     })
-  }
+  }, [logout, navigate])
 
   // Build menu items based on permissions using navigation constants
-  const hostsChildren: MenuItem[] = [
-    canView('proxy_hosts') && { 
-      text: NAVIGATION_CONFIG.proxyHosts.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.proxyHosts.icon, { sx: { color: NAVIGATION_CONFIG.proxyHosts.color } }), 
-      path: NAVIGATION_CONFIG.proxyHosts.path 
+  const hostsChildren = useMemo<MenuItem[]>(() => [
+    canView('proxy_hosts') && {
+      text: NAVIGATION_CONFIG.proxyHosts.text,
+      icon: React.createElement(NAVIGATION_CONFIG.proxyHosts.icon, { sx: { color: NAVIGATION_CONFIG.proxyHosts.color } }),
+      path: NAVIGATION_CONFIG.proxyHosts.path
     },
-    canView('redirection_hosts') && { 
-      text: NAVIGATION_CONFIG.redirectionHosts.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.redirectionHosts.icon, { sx: { color: NAVIGATION_CONFIG.redirectionHosts.color } }), 
-      path: NAVIGATION_CONFIG.redirectionHosts.path 
+    canView('redirection_hosts') && {
+      text: NAVIGATION_CONFIG.redirectionHosts.text,
+      icon: React.createElement(NAVIGATION_CONFIG.redirectionHosts.icon, { sx: { color: NAVIGATION_CONFIG.redirectionHosts.color } }),
+      path: NAVIGATION_CONFIG.redirectionHosts.path
     },
-    canView('dead_hosts') && { 
-      text: NAVIGATION_CONFIG.deadHosts.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.deadHosts.icon, { sx: { color: NAVIGATION_CONFIG.deadHosts.color } }), 
-      path: NAVIGATION_CONFIG.deadHosts.path 
+    canView('dead_hosts') && {
+      text: NAVIGATION_CONFIG.deadHosts.text,
+      icon: React.createElement(NAVIGATION_CONFIG.deadHosts.icon, { sx: { color: NAVIGATION_CONFIG.deadHosts.color } }),
+      path: NAVIGATION_CONFIG.deadHosts.path
     },
-    canView('streams') && { 
-      text: NAVIGATION_CONFIG.streams.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.streams.icon, { sx: { color: NAVIGATION_CONFIG.streams.color } }), 
-      path: NAVIGATION_CONFIG.streams.path 
+    canView('streams') && {
+      text: NAVIGATION_CONFIG.streams.text,
+      icon: React.createElement(NAVIGATION_CONFIG.streams.icon, { sx: { color: NAVIGATION_CONFIG.streams.color } }),
+      path: NAVIGATION_CONFIG.streams.path
     }
-  ].filter(Boolean) as MenuItem[]
+  ].filter(Boolean) as MenuItem[], [canView])
 
-  const securityChildren: MenuItem[] = [
-    canView('access_lists') && { 
-      text: NAVIGATION_CONFIG.accessLists.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.accessLists.icon, { sx: { color: NAVIGATION_CONFIG.accessLists.color } }), 
-      path: NAVIGATION_CONFIG.accessLists.path 
+  const securityChildren = useMemo<MenuItem[]>(() => [
+    canView('access_lists') && {
+      text: NAVIGATION_CONFIG.accessLists.text,
+      icon: React.createElement(NAVIGATION_CONFIG.accessLists.icon, { sx: { color: NAVIGATION_CONFIG.accessLists.color } }),
+      path: NAVIGATION_CONFIG.accessLists.path
     },
-    canView('certificates') && { 
-      text: NAVIGATION_CONFIG.certificates.text, 
-      icon: React.createElement(NAVIGATION_CONFIG.certificates.icon, { sx: { color: NAVIGATION_CONFIG.certificates.color } }), 
-      path: NAVIGATION_CONFIG.certificates.path 
+    canView('certificates') && {
+      text: NAVIGATION_CONFIG.certificates.text,
+      icon: React.createElement(NAVIGATION_CONFIG.certificates.icon, { sx: { color: NAVIGATION_CONFIG.certificates.color } }),
+      path: NAVIGATION_CONFIG.certificates.path
     }
-  ].filter(Boolean) as MenuItem[]
+  ].filter(Boolean) as MenuItem[], [canView])
 
-  const menuItems = [
+  const menuItems = useMemo(() => [
     {
       text: NAVIGATION_CONFIG.dashboard.text,
       icon: React.createElement(NAVIGATION_CONFIG.dashboard.icon, { sx: { color: NAVIGATION_CONFIG.dashboard.color } }),
@@ -149,33 +147,33 @@ const Layout = () => {
       onClick: () => setSecurityOpen(!securityOpen),
       children: securityChildren
     },
-  ].filter(Boolean) as MenuItem[]
+  ].filter(Boolean) as MenuItem[], [hostsChildren, hostsOpen, securityChildren, securityOpen])
 
-  const adminItems = [
+  const adminItems = useMemo(() => [
     {
       text: NAVIGATION_CONFIG.administration.text,
       icon: React.createElement(NAVIGATION_CONFIG.administration.icon, { sx: { color: NAVIGATION_CONFIG.administration.color } }),
       open: adminOpen,
       onClick: () => setAdminOpen(!adminOpen),
       children: [
-        { 
-          text: NAVIGATION_CONFIG.users.text, 
-          icon: React.createElement(NAVIGATION_CONFIG.users.icon, { sx: { color: NAVIGATION_CONFIG.users.color } }), 
-          path: NAVIGATION_CONFIG.users.path 
+        {
+          text: NAVIGATION_CONFIG.users.text,
+          icon: React.createElement(NAVIGATION_CONFIG.users.icon, { sx: { color: NAVIGATION_CONFIG.users.color } }),
+          path: NAVIGATION_CONFIG.users.path
         },
-        { 
-          text: NAVIGATION_CONFIG.auditLog.text, 
-          icon: React.createElement(NAVIGATION_CONFIG.auditLog.icon, { sx: { color: NAVIGATION_CONFIG.auditLog.color } }), 
-          path: NAVIGATION_CONFIG.auditLog.path 
+        {
+          text: NAVIGATION_CONFIG.auditLog.text,
+          icon: React.createElement(NAVIGATION_CONFIG.auditLog.icon, { sx: { color: NAVIGATION_CONFIG.auditLog.color } }),
+          path: NAVIGATION_CONFIG.auditLog.path
         },
-        { 
-          text: NAVIGATION_CONFIG.settings.text, 
-          icon: React.createElement(NAVIGATION_CONFIG.settings.icon, { sx: { color: NAVIGATION_CONFIG.settings.color } }), 
-          path: NAVIGATION_CONFIG.settings.path 
+        {
+          text: NAVIGATION_CONFIG.settings.text,
+          icon: React.createElement(NAVIGATION_CONFIG.settings.icon, { sx: { color: NAVIGATION_CONFIG.settings.color } }),
+          path: NAVIGATION_CONFIG.settings.path
         }
       ]
     }
-  ]
+  ], [adminOpen])
 
   const drawer = (
     <div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { 
   Typography, 
   Paper, 
@@ -150,7 +150,7 @@ const Dashboard = () => {
   const { canView } = usePermissions()
   const stats = useDashboardStats()
   
-  const statsCards = [
+  const statsCards = useMemo(() => [
     {
       title: 'Proxy Hosts',
       value: stats.proxyHosts.total,
@@ -207,9 +207,9 @@ const Dashboard = () => {
       path: '/security/access-lists',
       show: canView('access_lists')
     }
-  ]
+  ], [stats, canView])
 
-  const quickActions = [
+  const quickActions = useMemo(() => [
     {
       label: 'New Proxy Host',
       icon: <ProxyIcon />,
@@ -238,7 +238,7 @@ const Dashboard = () => {
       color: NAVIGATION_COLORS.primary,
       resource: 'access_lists'
     }
-  ]
+  ], [])
 
   return (
     <Box>

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useOptimistic, startTransition } from 'react'
+import React, { useState, useEffect, useOptimistic, startTransition, useMemo, useCallback } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import {
   Box,
@@ -108,19 +108,19 @@ export default function Streams() {
     }
   }
 
-  const handleCreateStream = () => {
+  const handleCreateStream = useCallback(() => {
     navigate('/hosts/streams/new')
-  }
+  }, [navigate])
 
-  const handleEditStream = (stream: Stream) => {
+  const handleEditStream = useCallback((stream: Stream) => {
     navigate(`/hosts/streams/${stream.id}/edit`)
-  }
+  }, [navigate])
 
-  const handleViewStream = (stream: Stream) => {
+  const handleViewStream = useCallback((stream: Stream) => {
     navigate(`/hosts/streams/${stream.id}/view`)
-  }
+  }, [navigate])
 
-  const handleDeleteStream = async () => {
+  const handleDeleteStream = useCallback(async () => {
     if (!streamToDelete) return
 
     try {
@@ -135,9 +135,9 @@ export default function Streams() {
       showError('stream', 'delete', err instanceof Error ? err.message : 'Unknown error', streamName, streamToDelete?.id)
       logger.error('Failed to delete stream:', err)
     }
-  }
+  }, [streamToDelete, showSuccess, showError, loadStreams])
 
-  const handleToggleEnabled = (stream: Stream) => {
+  const handleToggleEnabled = useCallback((stream: Stream) => {
     startTransition(async () => {
       // Optimistic update - UI changes instantly
       setOptimisticStream({ id: stream.id, enabled: !stream.enabled })
@@ -160,19 +160,19 @@ export default function Streams() {
         await loadStreams()
       }
     })
-  }
+  }, [showSuccess, showError])
 
-  const handleCloseDrawer = () => {
+  const handleCloseDrawer = useCallback(() => {
     setDrawerOpen(false)
     setSelectedStream(null)
     navigate('/hosts/streams')
-  }
+  }, [navigate])
 
-  const handleCloseDetails = () => {
+  const handleCloseDetails = useCallback(() => {
     setDetailsOpen(false)
     setSelectedStream(null)
     navigate('/hosts/streams')
-  }
+  }, [navigate])
 
   // Apply visibility filtering
   const visibleStreams = useFilteredData(optimisticStreams)
@@ -189,7 +189,7 @@ export default function Streams() {
   }
 
   // Column definitions for DataTable with responsive priorities
-  const columns: ResponsiveTableColumn<Stream>[] = [
+  const columns = useMemo<ResponsiveTableColumn<Stream>[]>(() => [
     {
       id: 'status',
       label: 'Status',
@@ -365,10 +365,10 @@ export default function Streams() {
         </Box>
       )
     }
-  ]
+  ], [handleViewStream, handleToggleEnabled, handleEditStream])
 
   // Filter definitions
-  const filters: Filter[] = [
+  const filters = useMemo<Filter[]>(() => [
     {
       id: 'protocols',
       label: 'Protocols',
@@ -384,7 +384,7 @@ export default function Streams() {
     {
       id: 'ssl',
       label: 'SSL',
-      type: 'select', 
+      type: 'select',
       defaultValue: 'all',
       options: [
         { value: 'all', label: 'All' },
@@ -403,10 +403,10 @@ export default function Streams() {
         { value: 'disabled', label: 'Disabled', icon: <CancelIcon fontSize="small" /> }
       ]
     }
-  ]
+  ], [])
 
   // Custom filter function for DataTable
-  const filterFunction = (item: Stream, activeFilters: Record<string, FilterValue>) => {
+  const filterFunction = useCallback((item: Stream, activeFilters: Record<string, FilterValue>) => {
     // Protocol filter
     if (activeFilters.protocols && activeFilters.protocols !== 'all') {
       if (activeFilters.protocols === 'tcp') {
@@ -436,10 +436,10 @@ export default function Streams() {
     }
 
     return true
-  }
+  }, [])
 
   // Bulk actions
-  const bulkActions: BulkAction<Stream>[] = [
+  const bulkActions = useMemo<BulkAction<Stream>[]>(() => [
     {
       id: 'enable',
       label: 'Enable',
@@ -486,7 +486,7 @@ export default function Streams() {
         }
       }
     }
-  ]
+  ], [showSuccess, showError, loadStreams])
 
   return (
     <Container maxWidth={false}>


### PR DESCRIPTION
## Summary
- Add `useMemo` for column definitions, filters, bulkActions, groupConfig, filterFunction, statsCards, quickActions, and menu items across 7 files
- Add `useCallback` for event handlers (handleEdit, handleDelete, handleToggleEnabled, etc.)
- Follow existing `Users.tsx` reference pattern for memoization

## Files Changed (7)
**Pages:** ProxyHosts, RedirectionHosts, DeadHosts, Streams, Certificates, Dashboard
**Components:** Layout

## Memoization Summary
| File | useMemo | useCallback |
|------|---------|-------------|
| ProxyHosts | 4 (columns, filters, bulkActions, groupConfig) | 7 (handlers + filterFunction) |
| RedirectionHosts | 4 (columns, filters, bulkActions, groupConfig) | 8 (handlers + filterFunction) |
| DeadHosts | 3 (columns, filters, bulkActions) | 7 (handlers + filterFunction) |
| Streams | 3 (columns, filters, bulkActions) | 8 (handlers + filterFunction) |
| Certificates | 4 (columns, groupConfig, filters, bulkActions) | 6 (handlers) |
| Dashboard | 2 (statsCards, quickActions) | 0 |
| Layout | 4 (hostsChildren, securityChildren, menuItems, adminItems) | 6 (handlers) |

## Verification
- `pnpm run typecheck`: 0 errors
- `pnpm run lint`: 0 errors (128 warnings, all pre-existing)

Closes #52