### PR TITLE
fix: accessibility improvements (aria-labels, keyboard navigation)

### DIFF
--- a/src/components/AccessListDetailsDialog.tsx
+++ b/src/components/AccessListDetailsDialog.tsx
@@ -173,8 +173,9 @@ const AccessListDetailsDialog = ({
                       primary={item.username}
                       secondary="Protected with password"
                     />
-                    <IconButton 
-                      size="small" 
+                    <IconButton
+                      size="small"
+                      aria-label="Copy to clipboard"
                       onClick={() => copyToClipboard(item.username, `User ${index + 1}`)}
                     >
                       <CopyIcon fontSize="small" />

--- a/src/components/AdaptiveContainer.tsx
+++ b/src/components/AdaptiveContainer.tsx
@@ -75,7 +75,7 @@ const AdaptiveContainer = ({
           ) : (
             title
           )}
-          <IconButton onClick={onClose} edge="end">
+          <IconButton onClick={onClose} edge="end" aria-label="Close">
             <CloseIcon />
           </IconButton>
         </Box>
@@ -127,6 +127,7 @@ const AdaptiveContainer = ({
         {title}
         <IconButton
           onClick={onClose}
+          aria-label="Close"
           sx={{
             position: 'absolute',
             right: 8,

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -183,14 +183,14 @@ export function DataTable<T extends object>({
                 <IconButton
                   size="small"
                   onClick={() => handleToggleAllGroups(true)}
-                  title="Expand All"
+                  aria-label="Expand All"
                 >
                   <ExpandAllIcon />
                 </IconButton>
                 <IconButton
                   size="small"
                   onClick={() => handleToggleAllGroups(false)}
-                  title="Collapse All"
+                  aria-label="Collapse All"
                 >
                   <CollapseAllIcon />
                 </IconButton>

--- a/src/components/DomainInput.tsx
+++ b/src/components/DomainInput.tsx
@@ -322,6 +322,7 @@ export default function DomainInput({
               {!disabled && (
                 <IconButton
                   size="small"
+                  aria-label="Remove domain"
                   onClick={() => {
                     const originalIndex = value.indexOf(domain)
                     handleDelete(originalIndex)

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -171,7 +171,7 @@ const Layout = () => {
       <Box
         component="nav"
         sx={{ width: { lg: LAYOUT.DRAWER_WIDTH }, flexShrink: { lg: 0 } }}
-        aria-label="mailbox folders"
+        aria-label="Main navigation"
       >
         <Drawer
           variant="temporary"

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -11,13 +11,16 @@ const Logo = ({ width = 210, color = 'currentColor' }: LogoProps) => {
   const actualHeight = width / aspectRatio
   
   return (
-    <svg 
-      width={width} 
-      height={actualHeight} 
-      viewBox="0 0 210 83" 
-      version="1.1" 
+    <svg
+      width={width}
+      height={actualHeight}
+      viewBox="0 0 210 83"
+      version="1.1"
       xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="NPMDeck Logo"
     >
+      <title>NPMDeck Logo</title>
       <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <polygon 
           id="Path" 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -142,6 +142,7 @@ const SearchBar = () => {
 
   return (
     <Autocomplete
+      aria-label="Search proxy hosts, certificates, and more"
       open={open}
       onOpen={() => {
         if (!preventReopen) {

--- a/src/components/StreamDetailsDialog.tsx
+++ b/src/components/StreamDetailsDialog.tsx
@@ -123,8 +123,9 @@ const StreamDetailsDialog = ({
                   <Typography variant="body1">
                     {stream.incoming_port}
                   </Typography>
-                  <IconButton 
-                    size="small" 
+                  <IconButton
+                    size="small"
+                    aria-label="Copy to clipboard"
                     onClick={() => copyToClipboard(stream.incoming_port.toString(), 'Port')}
                   >
                     <CopyIcon fontSize="small" />
@@ -153,20 +154,21 @@ const StreamDetailsDialog = ({
                   <Typography variant="body1">
                     {stream.forwarding_host}:{stream.forwarding_port}
                   </Typography>
-                  <IconButton 
-                    size="small" 
+                  <IconButton
+                    size="small"
+                    aria-label="Copy to clipboard"
                     onClick={() => copyToClipboard(`${stream.forwarding_host}:${stream.forwarding_port}`, 'Destination')}
                   >
                     <CopyIcon fontSize="small" />
                   </IconButton>
                   <IconButton
                     size="small"
+                    aria-label="Open in new tab"
                     onClick={() => {
                       const protocol = stream.certificate_id ? 'https' : 'http'
                       const url = `${protocol}://${stream.forwarding_host}:${stream.forwarding_port}`
                       window.open(url, '_blank', 'noopener,noreferrer')
                     }}
-                    title="Open in new tab"
                   >
                     <OpenInNewIcon fontSize="small" />
                   </IconButton>

--- a/src/components/features/certificates/CertificateHostsPanel.tsx
+++ b/src/components/features/certificates/CertificateHostsPanel.tsx
@@ -59,9 +59,10 @@ const CertificateHostsPanel = ({
                 <ListItem
                   key={host.id}
                   secondaryAction={
-                    <IconButton 
-                      edge="end" 
-                      size="small" 
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      aria-label="View proxy host"
                       onClick={() => onNavigateToHost('proxy', host.id)}
                     >
                       <OpenInNewIcon fontSize="small" />
@@ -88,9 +89,10 @@ const CertificateHostsPanel = ({
                 <ListItem
                   key={host.id}
                   secondaryAction={
-                    <IconButton 
-                      edge="end" 
-                      size="small" 
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      aria-label="View redirection host"
                       onClick={() => onNavigateToHost('redirection', host.id)}
                     >
                       <OpenInNewIcon fontSize="small" />
@@ -117,9 +119,10 @@ const CertificateHostsPanel = ({
                 <ListItem
                   key={host.id}
                   secondaryAction={
-                    <IconButton 
-                      edge="end" 
-                      size="small" 
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      aria-label="View 404 host"
                       onClick={() => onNavigateToHost('404', host.id)}
                     >
                       <OpenInNewIcon fontSize="small" />

--- a/src/components/features/certificates/CertificateInfoPanel.tsx
+++ b/src/components/features/certificates/CertificateInfoPanel.tsx
@@ -97,8 +97,9 @@ const CertificateInfoPanel = ({
               <Typography variant="body2" fontFamily="monospace">
                 #{certificate.id}
               </Typography>
-              <IconButton 
-                size="small" 
+              <IconButton
+                size="small"
+                aria-label="Copy to clipboard"
                 onClick={() => onCopyToClipboard(certificate.id.toString(), 'Certificate ID')}
               >
                 <CopyIcon fontSize="small" />
@@ -115,8 +116,9 @@ const CertificateInfoPanel = ({
                 <Typography variant="body2" fontFamily="monospace">
                   {certificate.meta.certificate_id}
                 </Typography>
-                <IconButton 
-                  size="small" 
+                <IconButton
+                  size="small"
+                  aria-label="Copy to clipboard"
                   onClick={() => onCopyToClipboard(certificate.meta.certificate_id!, 'LE Certificate ID')}
                 >
                   <CopyIcon fontSize="small" />

--- a/src/components/features/dead-hosts/BasicInfoPanel.tsx
+++ b/src/components/features/dead-hosts/BasicInfoPanel.tsx
@@ -54,8 +54,9 @@ const BasicInfoPanel = ({ host, onCopyToClipboard }: BasicInfoPanelProps) => {
             }}>
               #{host.id}
             </Typography>
-            <IconButton 
-              size="small" 
+            <IconButton
+              size="small"
+              aria-label="Copy to clipboard"
               onClick={() => onCopyToClipboard(host.id.toString(), 'Host ID')}
             >
               <CopyIcon fontSize="small" />

--- a/src/components/features/dead-hosts/DomainNamesPanel.tsx
+++ b/src/components/features/dead-hosts/DomainNamesPanel.tsx
@@ -45,9 +45,10 @@ const DomainNamesPanel = ({ domainNames, onCopyToClipboard }: DomainNamesPanelPr
             <ListItem
               key={index}
               secondaryAction={
-                <IconButton 
-                  edge="end" 
-                  size="small" 
+                <IconButton
+                  edge="end"
+                  size="small"
+                  aria-label="Copy to clipboard"
                   onClick={() => onCopyToClipboard(domain, domain)}
                 >
                   <CopyIcon fontSize="small" />

--- a/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
@@ -106,6 +106,7 @@ const ProxyHostConnectionsPanel = ({
                   />
                   <IconButton
                     edge="end"
+                    aria-label="Edit redirection"
                     onClick={(e) => {
                       e.stopPropagation()
                       onEditRedirection(redirect.id)

--- a/src/components/features/proxy-hosts/ProxyHostInfoPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostInfoPanel.tsx
@@ -188,8 +188,9 @@ const ProxyHostInfoPanel = ({
               }}>
                 #{host.id}
               </Typography>
-              <IconButton 
-                size="small" 
+              <IconButton
+                size="small"
+                aria-label="Copy to clipboard"
                 onClick={() => onCopyToClipboard(host.id.toString(), 'Host ID')}
               >
                 <CopyIcon fontSize="small" />
@@ -300,9 +301,10 @@ const ProxyHostInfoPanel = ({
               <ListItem
                 key={index}
                 secondaryAction={
-                  <IconButton 
-                    edge="end" 
-                    size="small" 
+                  <IconButton
+                    edge="end"
+                    size="small"
+                    aria-label="Copy to clipboard"
                     onClick={() => onCopyToClipboard(domain, domain)}
                   >
                     <CopyIcon fontSize="small" />

--- a/src/components/layout/DrawerUserInfoSection.tsx
+++ b/src/components/layout/DrawerUserInfoSection.tsx
@@ -24,14 +24,17 @@ const DrawerUserInfoSection = ({ userName, userEmail, isAdmin, onMenuOpen }: Dra
   return (
     <Box sx={{ mt: 'auto' }}>
       <Divider sx={{ mb: 0 }} />
-      <Box 
-        sx={{ 
-          p: 2, 
-          display: 'flex', 
-          alignItems: 'center', 
+      <Box
+        role="button"
+        tabIndex={0}
+        aria-label="Open user menu"
+        sx={{
+          p: 2,
+          display: 'flex',
+          alignItems: 'center',
           gap: 2,
-          backgroundColor: (theme) => theme.palette.mode === 'dark' 
-            ? 'rgba(255, 255, 255, 0.05)' 
+          backgroundColor: (theme) => theme.palette.mode === 'dark'
+            ? 'rgba(255, 255, 255, 0.05)'
             : 'rgba(0, 0, 0, 0.04)',
           cursor: 'pointer',
           '&:hover': {
@@ -41,6 +44,12 @@ const DrawerUserInfoSection = ({ userName, userEmail, isAdmin, onMenuOpen }: Dra
           }
         }}
         onClick={onMenuOpen}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onMenuOpen(e as unknown as React.MouseEvent<HTMLElement>)
+          }
+        }}
       >
         <Avatar
           sx={{

--- a/src/hooks/useProxyHostColumns.tsx
+++ b/src/hooks/useProxyHostColumns.tsx
@@ -95,6 +95,7 @@ const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTable
                 </Typography>
                 <IconButton
                   size="small"
+                  aria-label="Open domain in new tab"
                   sx={{
                     p: 0.25,
                     '&:hover': {
@@ -123,12 +124,26 @@ const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTable
                 }
               >
                 <Box
+                  role="link"
+                  tabIndex={0}
+                  aria-label={`View ${linkedRedirections.length} linked redirection${linkedRedirections.length > 1 ? 's' : ''}`}
                   onClick={(e) => {
                     e.stopPropagation()
                     if (linkedRedirections.length === 1) {
                       navigate(`/hosts/redirection/${linkedRedirections[0].id}/view`)
                     } else {
                       onViewConnections(item)
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      if (linkedRedirections.length === 1) {
+                        navigate(`/hosts/redirection/${linkedRedirections[0].id}/view`)
+                      } else {
+                        onViewConnections(item)
+                      }
                     }
                   }}
                   sx={{
@@ -176,6 +191,7 @@ const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTable
           </Typography>
           <IconButton
             size="small"
+            aria-label="Open forward host in new tab"
             sx={{
               p: 0.25,
               '&:hover': {

--- a/src/hooks/useRedirectionHostColumns.tsx
+++ b/src/hooks/useRedirectionHostColumns.tsx
@@ -81,6 +81,7 @@ const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): Res
               </Typography>
               <IconButton
                 size="small"
+                aria-label="Open source domain in new tab"
                 sx={{
                   p: 0.25,
                   '&:hover': {
@@ -126,6 +127,7 @@ const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): Res
               </Typography>
               <IconButton
                 size="small"
+                aria-label="Open destination in new tab"
                 sx={{
                   p: 0.25,
                   '&:hover': {
@@ -142,7 +144,17 @@ const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): Res
             </Box>
             {linkedProxy && (
               <Box
+                role="link"
+                tabIndex={0}
+                aria-label="View linked proxy host"
                 onClick={(e) => onViewProxyHost(linkedProxy, e)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onViewProxyHost(linkedProxy, e as unknown as React.MouseEvent)
+                  }
+                }}
                 sx={{
                   display: "flex",
                   alignItems: "center",

--- a/src/pages/Certificates.tsx
+++ b/src/pages/Certificates.tsx
@@ -303,6 +303,7 @@ const Certificates = () => {
           <Tooltip title="View Details">
             <IconButton
               size="small"
+              aria-label="View certificate details"
               onClick={(e) => {
                 e.stopPropagation()
                 handleView(item)
@@ -315,6 +316,7 @@ const Certificates = () => {
             <Tooltip title="Renew">
               <IconButton
                 size="small"
+                aria-label="Renew certificate"
                 onClick={(e) => {
                   e.stopPropagation()
                   handleRenew(item)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -57,8 +57,11 @@ const StatCard = ({ title, value, icon, color, path, active, inactive, loading }
   
   
   return (
-    <Card 
-      sx={{ 
+    <Card
+      role="link"
+      tabIndex={0}
+      aria-label={`Navigate to ${title}`}
+      sx={{
         height: '100%',
         cursor: 'pointer',
         transition: 'background-color 0.2s',
@@ -67,6 +70,12 @@ const StatCard = ({ title, value, icon, color, path, active, inactive, loading }
         }
       }}
       onClick={() => navigate(path)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate(path)
+        }
+      }}
     >
       <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
         {loading ? (

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -140,6 +140,7 @@ export default function Streams() {
           <Tooltip title="Open in new tab">
             <IconButton
               size="small"
+              aria-label="Open stream endpoint in new tab"
               onClick={(e) => {
                 e.stopPropagation()
                 // Determine the protocol - use http by default


### PR DESCRIPTION
## Summary

- Add descriptive `aria-label` attributes to 20+ IconButtons across pages and detail dialogs (copy, open-in-new-tab, view, renew, delete, edit, close buttons)
- Add keyboard navigation (`role`, `tabIndex`, `onKeyDown`) to interactive non-button elements (DrawerUserInfoSection, Dashboard StatCards, linked redirection/proxy host boxes)
- Replace MUI placeholder `aria-label="mailbox folders"` with `"Main navigation"`
- Add `aria-label` to SearchBar Autocomplete and Close buttons in AdaptiveContainer
- Add `<title>`, `role="img"`, and `aria-label` to Logo SVG for screen reader support
- Replace `title` with `aria-label` on DataTable expand/collapse buttons

Closes #56

## Test plan

- [x] Verify all IconButtons are announced correctly by screen readers
- [x] Tab through Dashboard StatCards and verify Enter/Space triggers navigation
- [x] Tab to DrawerUserInfoSection and verify Enter/Space opens user menu
- [x] Tab to linked redirection/proxy host links in data tables and verify keyboard activation
- [x] Verify SearchBar is announced with descriptive label
- [x] Verify Logo SVG is announced as "NPMDeck Logo"
- [x] Verify Close buttons in drawers/dialogs are announced as "Close"
- [x] Run `pnpm run lint` — passes with 0 errors
- [x] Run `pnpm run typecheck` — passes with no errors