### PR TITLE
fix: improve error handling (ErrorBoundaries, Promise.allSettled)

### DIFF
--- a/src/components/PageErrorBoundary.tsx
+++ b/src/components/PageErrorBoundary.tsx
@@ -1,0 +1,157 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+import { Box, Typography, Button, Alert, Paper } from '@mui/material'
+import { Refresh as RefreshIcon, ErrorOutline as ErrorIcon } from '@mui/icons-material'
+import logger from '../utils/logger'
+
+interface PageErrorBoundaryProps {
+  children: ReactNode
+  onReset?: () => void
+}
+
+interface PageErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Checks whether an error is caused by a failed dynamic import (chunk load failure).
+ * This typically happens when a new deployment invalidates cached chunk hashes
+ * and the browser tries to load stale chunk URLs.
+ */
+function isChunkLoadError(error: Error): boolean {
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('loading chunk') ||
+    message.includes('loading css chunk') ||
+    message.includes('dynamically imported module') ||
+    message.includes('failed to fetch')
+  )
+}
+
+/**
+ * A lightweight error boundary for page-level use.
+ * Unlike the global ErrorBoundary, this renders inline within the page area
+ * and does not disrupt navigation or the app shell layout.
+ *
+ * Handles two categories of errors:
+ * - Chunk load errors (stale deploys) — prompts the user to reload the page
+ * - General errors — provides a "Try Again" button that resets the boundary
+ */
+class PageErrorBoundary extends Component<PageErrorBoundaryProps, PageErrorBoundaryState> {
+  public state: PageErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
+
+  public static getDerivedStateFromError(error: Error): PageErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    logger.error('PageErrorBoundary caught an error:', { error, errorInfo })
+  }
+
+  private handleTryAgain = (): void => {
+    this.setState({ hasError: false, error: null })
+    this.props.onReset?.()
+  }
+
+  private handleReload = (): void => {
+    window.location.reload()
+  }
+
+  public render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    const { error } = this.state
+    const chunkError = error !== null && isChunkLoadError(error)
+
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'flex-start',
+          py: 4,
+          px: 2,
+        }}
+      >
+        <Paper
+          elevation={0}
+          sx={{
+            p: 4,
+            maxWidth: 520,
+            width: '100%',
+            textAlign: 'center',
+          }}
+        >
+          <ErrorIcon sx={{ fontSize: 48, color: 'error.main', mb: 2 }} />
+
+          {chunkError ? (
+            <>
+              <Typography variant="h6" gutterBottom>
+                Loading Failed
+              </Typography>
+              <Alert severity="warning" sx={{ mb: 3, textAlign: 'left' }}>
+                A newer version of the application may be available, or a network
+                error occurred while loading this page. Please reload to continue.
+              </Alert>
+              <Button
+                variant="contained"
+                startIcon={<RefreshIcon />}
+                onClick={this.handleReload}
+              >
+                Reload Page
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography variant="h6" gutterBottom>
+                Something went wrong
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 3 }}
+              >
+                An unexpected error occurred while rendering this section.
+                You can try again or navigate to a different page.
+              </Typography>
+
+              {import.meta.env.DEV && error !== null && (
+                <Alert severity="error" sx={{ mb: 3, textAlign: 'left' }}>
+                  <Typography
+                    variant="caption"
+                    component="pre"
+                    sx={{
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      m: 0,
+                    }}
+                  >
+                    {error.message}
+                    {error.stack ? `\n\n${error.stack}` : ''}
+                  </Typography>
+                </Alert>
+              )}
+
+              <Button
+                variant="contained"
+                startIcon={<RefreshIcon />}
+                onClick={this.handleTryAgain}
+              >
+                Try Again
+              </Button>
+            </>
+          )}
+        </Paper>
+      </Box>
+    )
+  }
+}
+
+export default PageErrorBoundary

--- a/src/components/features/proxy-hosts/ProxyHostAccessPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostAccessPanel.tsx
@@ -10,6 +10,7 @@ import {
   Paper,
   CircularProgress,
   ListItemIcon,
+  Alert,
 } from '@mui/material'
 import {
   Security as SecurityIcon,
@@ -26,6 +27,7 @@ interface ProxyHostAccessPanelProps {
   host: ProxyHost
   fullAccessList: AccessList | null
   loadingAccessList: boolean
+  error?: string | null
   onNavigateToFullAccessList: () => void
 }
 
@@ -33,10 +35,19 @@ const ProxyHostAccessPanel = ({
   host,
   fullAccessList,
   loadingAccessList,
+  error,
   onNavigateToFullAccessList,
 }: ProxyHostAccessPanelProps) => {
   if (!host.access_list) {
     return null
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error" sx={{ mb: 2 }}>
+        {error}
+      </Alert>
+    )
   }
 
   if (loadingAccessList) {

--- a/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostConnectionsPanel.tsx
@@ -22,6 +22,7 @@ import { RedirectionHost } from '../../../api/redirectionHosts'
 interface ProxyHostConnectionsPanelProps {
   linkedRedirections: RedirectionHost[]
   loadingConnections: boolean
+  error?: string | null
   onNavigateToRedirection: (redirectionId: number) => void
   onEditRedirection: (redirectionId: number) => void
 }
@@ -29,11 +30,17 @@ interface ProxyHostConnectionsPanelProps {
 const ProxyHostConnectionsPanel = ({
   linkedRedirections,
   loadingConnections,
+  error,
   onNavigateToRedirection,
   onEditRedirection,
 }: ProxyHostConnectionsPanelProps) => {
   return (
     <Box>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
       <Box
         sx={{
           display: "flex",

--- a/src/pages/DeadHosts.tsx
+++ b/src/pages/DeadHosts.tsx
@@ -38,7 +38,7 @@ import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { getStatusIcon } from '../utils/statusUtils'
 
 export default function DeadHosts() {
-  const { showSuccess, showError } = useToast()
+  const { showSuccess, showError, showWarning } = useToast()
   const { isMobileTable } = useResponsive()
 
   const {
@@ -273,8 +273,9 @@ export default function DeadHosts() {
     entityLabel: '404 hosts',
     showSuccess,
     showError,
+    showWarning,
     loadItems,
-  }), [showSuccess, showError, loadItems])
+  }), [showSuccess, showError, showWarning, loadItems])
 
   return (
     <Container maxWidth={false}>

--- a/src/pages/ProxyHosts.tsx
+++ b/src/pages/ProxyHosts.tsx
@@ -47,7 +47,7 @@ const buildRedirectionTargetMap = async (): Promise<RedirectionsByTarget> => {
 
 export default function ProxyHosts() {
   const navigate = useNavigate()
-  const { showSuccess, showError } = useToast()
+  const { showSuccess, showError, showWarning } = useToast()
   const { isMobileTable } = useResponsive()
 
   // Entity CRUD hook handles all state, URL routing, dialogs, and data loading
@@ -118,9 +118,10 @@ export default function ProxyHosts() {
       entityLabel: PROXY_HOST_ENTITY_LABEL,
       showSuccess,
       showError,
+      showWarning,
       loadItems,
     }),
-    [showSuccess, showError, loadItems]
+    [showSuccess, showError, showWarning, loadItems]
   )
 
   // Group configuration for domain grouping

--- a/src/pages/RedirectionHosts.tsx
+++ b/src/pages/RedirectionHosts.tsx
@@ -38,7 +38,7 @@ const buildProxyHostDomainMap = async (): Promise<Map<string, ProxyHost>> => {
 
 export default function RedirectionHosts() {
   const navigate = useNavigate()
-  const { showSuccess, showError } = useToast()
+  const { showSuccess, showError, showWarning } = useToast()
   const { isMobileTable } = useResponsive()
 
   const {
@@ -101,9 +101,10 @@ export default function RedirectionHosts() {
       entityLabel: 'redirection hosts',
       showSuccess,
       showError,
+      showWarning,
       loadItems,
     }),
-    [showSuccess, showError, loadItems]
+    [showSuccess, showError, showWarning, loadItems]
   )
 
   // Group configuration for domain grouping

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -44,7 +44,7 @@ const getStreamDisplayName = (stream: Stream): string =>
   `${stream.incoming_port}/${stream.tcp_forwarding ? 'TCP' : ''}${stream.udp_forwarding ? 'UDP' : ''}`
 
 export default function Streams() {
-  const { showSuccess, showError } = useToast()
+  const { showSuccess, showError, showWarning } = useToast()
   const { isMobileTable } = useResponsive()
 
   const {
@@ -346,8 +346,9 @@ export default function Streams() {
     entityLabel: 'streams',
     showSuccess,
     showError,
+    showWarning,
     loadItems,
-  }), [showSuccess, showError, loadItems])
+  }), [showSuccess, showError, showWarning, loadItems])
 
   return (
     <Container maxWidth={false}>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -4,6 +4,7 @@ import { CircularProgress, Box } from '@mui/material'
 import ProtectedRoute from './components/ProtectedRoute'
 import PermissionRoute from './components/PermissionRoute'
 import LayoutWithSearch from './components/LayoutWithSearch'
+import PageErrorBoundary from './components/PageErrorBoundary'
 
 // Loading component
 const PageLoader = () => (
@@ -18,11 +19,13 @@ const PageLoader = () => (
   </Box>
 )
 
-// Wrap lazy components in Suspense
+// Wrap lazy components in ErrorBoundary + Suspense to catch chunk load failures
 const withSuspense = (Component: React.LazyExoticComponent<any>) => (
-  <Suspense fallback={<PageLoader />}>
-    <Component />
-  </Suspense>
+  <PageErrorBoundary>
+    <Suspense fallback={<PageLoader />}>
+      <Component />
+    </Suspense>
+  </PageErrorBoundary>
 )
 
 // Lazy load pages


### PR DESCRIPTION
## Summary

- Add `PageErrorBoundary` component for page-level error catching with chunk load retry UI
- Wrap all lazy-loaded routes with `PageErrorBoundary` in `routes.tsx`
- Replace `Promise.all` with `Promise.allSettled` in all bulk operations (enable/disable/delete) with partial success/failure reporting via `showWarning`
- Add inline error alerts to `ProxyHostDetailsDialog` when loading connections or access list details fails
- Add JWT validation guard to `pushCurrentToStack()` in authStore

## Changes

| Area | Files | What |
|------|-------|------|
| ErrorBoundary | `PageErrorBoundary.tsx`, `routes.tsx` | New component + wrapping lazy routes |
| Bulk operations | `bulkActionFactory.tsx`, `Certificates.tsx`, `AccessLists.tsx`, `ImportExport.tsx` | `Promise.allSettled` + partial failure reporting |
| Bulk callers | `ProxyHosts.tsx`, `RedirectionHosts.tsx`, `DeadHosts.tsx`, `Streams.tsx` | Pass `showWarning` to factory |
| Dialog feedback | `ProxyHostDetailsDialog.tsx`, `ProxyHostConnectionsPanel.tsx`, `ProxyHostAccessPanel.tsx` | Error state + inline Alert |
| JWT safety | `authStore.ts` | `isValidJWT` guard + try/catch |

Closes #57

## Test plan

- [x] Navigate to all pages — verify they load normally without errors
- [x] Verify bulk enable/disable/delete operations still work on ProxyHosts, Streams, DeadHosts, RedirectionHosts
- [x] Simulate partial bulk failure (e.g. delete a host that's in use) and verify warning toast shows succeeded/failed counts
- [x] Open ProxyHost details dialog — verify connections and access list tabs load
- [x] Verify chunk load error UI by simulating import failure in dev tools
- [x] Verify `pnpm run typecheck` passes
- [x] Verify `pnpm run lint` shows no new errors