### PR TITLE
fix: post-overhaul cleanup and React pattern fixes

### DIFF
--- a/src/components/features/certificates/CertificateDrawer.tsx
+++ b/src/components/features/certificates/CertificateDrawer.tsx
@@ -3,11 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import {
   TextField,
   FormControlLabel,
-  // FormControl,
   Switch,
   Box,
-  // RadioGroup,
-  // Radio,
   Alert,
   Button,
   Stack,

--- a/src/components/features/index.ts
+++ b/src/components/features/index.ts
@@ -5,6 +5,5 @@ export { default as AccessListDrawer } from './access-lists/AccessListDrawer'
 
 export { default as SearchResultItem } from './search/SearchResultItem'
 
-// TODO: Add exports for other refactored components as they are completed
 export { default as StreamDrawer } from './streams/StreamDrawer'
 export { default as DeadHostDrawer } from './dead-hosts/DeadHostDrawer'

--- a/src/components/features/proxy-hosts/ProxyHostDrawer.tsx
+++ b/src/components/features/proxy-hosts/ProxyHostDrawer.tsx
@@ -303,7 +303,7 @@ export default function ProxyHostDrawer({ open, onClose, host, onSave }: ProxyHo
 interface DetailsTabProps {
   data: ProxyHostFormData
   setFieldValue: (field: keyof ProxyHostFormData, value: ProxyHostFormData[keyof ProxyHostFormData]) => void
-  errors: Record<string, string>
+  errors: Partial<Record<keyof ProxyHostFormData, string>>
   accessLists: AccessList[]
   _loadingData: boolean
 }
@@ -426,7 +426,7 @@ DetailsTab.displayName = 'DetailsTab'
 interface SSLTabProps {
   data: ProxyHostFormData
   setFieldValue: (field: keyof ProxyHostFormData, value: ProxyHostFormData[keyof ProxyHostFormData]) => void
-  errors: Record<string, string>
+  errors: Partial<Record<keyof ProxyHostFormData, string>>
   certificates: Certificate[]
   _loadingData: boolean
 }
@@ -521,7 +521,7 @@ SSLTab.displayName = 'SSLTab'
 interface AdvancedTabProps {
   data: ProxyHostFormData
   setFieldValue: (field: keyof ProxyHostFormData, value: ProxyHostFormData[keyof ProxyHostFormData]) => void
-  errors: Record<string, string>
+  errors: Partial<Record<keyof ProxyHostFormData, string>>
 }
 
 const AdvancedTab = React.memo(({ data, setFieldValue, errors: _errors }: AdvancedTabProps) => {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -133,14 +133,13 @@ function formatEntityType(entityType: EntityType): string {
 }
 
 /**
- * Custom Toast Component
+ * Shared Alert content used by both demo and non-demo toast modes
  */
-export function CustomToast({ toast, onClose, demo = false }: { toast: ToastMessage; onClose: () => void; demo?: boolean }) {
+function ToastAlertContent({ toast }: { toast: ToastMessage }) {
   const theme = useTheme();
   const EntityIcon = toast.entityType ? getEntityIcon(toast.entityType) : InfoIcon;
   const ActionIcon = getActionIcon(toast.action);
-  
-  // Get severity icon
+
   const getSeverityIcon = () => {
     switch (toast.severity) {
       case 'success':
@@ -154,185 +153,117 @@ export function CustomToast({ toast, onClose, demo = false }: { toast: ToastMess
         return InfoIcon;
     }
   };
-  
+
   const SeverityIcon = getSeverityIcon();
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+      {/* Icon section */}
+      <Box sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        mt: 0.25
+      }}>
+        {ActionIcon ? (
+          <Box sx={{ position: 'relative' }}>
+            <EntityIcon sx={{ fontSize: 24, opacity: 0.9 }} />
+            <Box
+              sx={{
+                position: 'absolute',
+                bottom: -4,
+                right: -4,
+                backgroundColor: theme.palette.mode === 'dark'
+                  ? theme.palette.background.paper
+                  : 'white',
+                borderRadius: '50%',
+                width: 16,
+                height: 16,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <ActionIcon sx={{ fontSize: 12, color: theme.palette[toast.severity].main }} />
+            </Box>
+          </Box>
+        ) : (
+          <SeverityIcon sx={{ fontSize: 24 }} />
+        )}
+      </Box>
+
+      {/* Content section */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        {toast.entityType && (
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              opacity: 0.9,
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              fontSize: '0.65rem',
+              mb: 0.25
+            }}
+          >
+            {formatEntityType(toast.entityType)}
+          </Typography>
+        )}
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 500,
+            wordBreak: 'break-word'
+          }}
+        >
+          {toast.message}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Custom Toast Component
+ */
+export function CustomToast({ toast, onClose, demo = false }: { toast: ToastMessage; onClose: () => void; demo?: boolean }) {
+  const theme = useTheme();
 
   // Set up auto-hide timer
   React.useEffect(() => {
     if (!toast.duration) return
-    
+
     const timer = setTimeout(() => {
       onClose();
     }, toast.duration);
     return () => clearTimeout(timer);
   }, [toast.duration, onClose]);
 
-  // For demo mode, just return the Alert without Snackbar wrapper
+  const alertSx = {
+    width: '100%',
+    maxWidth: 500,
+    backgroundColor: theme.palette.mode === 'dark'
+      ? alpha(theme.palette[toast.severity].main, 0.9)
+      : theme.palette[toast.severity].main,
+    '& .MuiAlert-icon': {
+      display: 'none'
+    },
+    ...(!demo && { boxShadow: 3 }),
+  };
+
+  // For demo mode, just return the Alert without Slide wrapper
   if (demo) {
     return (
-      <Alert
-        onClose={onClose}
-        severity={toast.severity}
-        variant="filled"
-        sx={{ 
-          width: '100%', 
-          maxWidth: 500,
-          backgroundColor: theme.palette.mode === 'dark' 
-            ? alpha(theme.palette[toast.severity].main, 0.9)
-            : theme.palette[toast.severity].main,
-          '& .MuiAlert-icon': {
-            display: 'none' // We'll use custom icon layout
-          }
-        }}
-      >
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
-          {/* Icon section */}
-          <Box sx={{ 
-            display: 'flex', 
-            alignItems: 'center',
-            flexShrink: 0,
-            mt: 0.25
-          }}>
-            {ActionIcon ? (
-              <Box sx={{ position: 'relative' }}>
-                <EntityIcon sx={{ fontSize: 24, opacity: 0.9 }} />
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    bottom: -4,
-                    right: -4,
-                    backgroundColor: theme.palette.mode === 'dark'
-                      ? theme.palette.background.paper
-                      : 'white',
-                    borderRadius: '50%',
-                    width: 16,
-                    height: 16,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <ActionIcon sx={{ fontSize: 12, color: theme.palette[toast.severity].main }} />
-                </Box>
-              </Box>
-            ) : (
-              <SeverityIcon sx={{ fontSize: 24 }} />
-            )}
-          </Box>
-          
-          {/* Content section */}
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            {toast.entityType && (
-              <Typography
-                variant="caption"
-                sx={{
-                  display: 'block',
-                  opacity: 0.9,
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.5,
-                  fontSize: '0.65rem',
-                  mb: 0.25
-                }}
-              >
-                {formatEntityType(toast.entityType)}
-              </Typography>
-            )}
-            <Typography
-              variant="body2"
-              sx={{
-                fontWeight: 500,
-                wordBreak: 'break-word'
-              }}
-            >
-              {toast.message}
-            </Typography>
-          </Box>
-        </Box>
+      <Alert onClose={onClose} severity={toast.severity} variant="filled" sx={alertSx}>
+        <ToastAlertContent toast={toast} />
       </Alert>
     );
   }
 
   return (
     <Slide direction="down" in={true} mountOnEnter unmountOnExit>
-      <Alert
-        onClose={onClose}
-        severity={toast.severity}
-        variant="filled"
-        sx={{ 
-          width: '100%', 
-          maxWidth: 500,
-          backgroundColor: theme.palette.mode === 'dark' 
-            ? alpha(theme.palette[toast.severity].main, 0.9)
-            : theme.palette[toast.severity].main,
-          '& .MuiAlert-icon': {
-            display: 'none' // We'll use custom icon layout
-          },
-          boxShadow: 3,
-        }}
-      >
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
-          {/* Icon section */}
-          <Box sx={{ 
-            display: 'flex', 
-            alignItems: 'center',
-            flexShrink: 0,
-            mt: 0.25
-          }}>
-            {ActionIcon ? (
-              <Box sx={{ position: 'relative' }}>
-                <EntityIcon sx={{ fontSize: 24, opacity: 0.9 }} />
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    bottom: -4,
-                    right: -4,
-                    backgroundColor: theme.palette.mode === 'dark'
-                      ? theme.palette.background.paper
-                      : 'white',
-                    borderRadius: '50%',
-                    width: 16,
-                    height: 16,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <ActionIcon sx={{ fontSize: 12, color: theme.palette[toast.severity].main }} />
-                </Box>
-              </Box>
-            ) : (
-              <SeverityIcon sx={{ fontSize: 24 }} />
-            )}
-          </Box>
-          
-          {/* Content section */}
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            {toast.entityType && (
-              <Typography
-                variant="caption"
-                sx={{
-                  display: 'block',
-                  opacity: 0.9,
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.5,
-                  fontSize: '0.65rem',
-                  mb: 0.25
-                }}
-              >
-                {formatEntityType(toast.entityType)}
-              </Typography>
-            )}
-            <Typography
-              variant="body2"
-              sx={{
-                fontWeight: 500,
-                wordBreak: 'break-word'
-              }}
-            >
-              {toast.message}
-            </Typography>
-          </Box>
-        </Box>
+      <Alert onClose={onClose} severity={toast.severity} variant="filled" sx={alertSx}>
+        <ToastAlertContent toast={toast} />
       </Alert>
     </Slide>
   );

--- a/src/hooks/useProxyHostColumns.tsx
+++ b/src/hooks/useProxyHostColumns.tsx
@@ -82,9 +82,9 @@ const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTable
         const linkedRedirections = getLinkedRedirections(item)
         return (
           <Box>
-            {item.domain_names.map((domain: string, index: number) => (
+            {item.domain_names.map((domain: string) => (
               <Box
-                key={index}
+                key={domain}
                 sx={{
                   display: "flex",
                   alignItems: "center",
@@ -115,8 +115,8 @@ const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTable
               <Tooltip
                 title={
                   <Box>
-                    {linkedRedirections.map((redirect, idx) => (
-                      <div key={idx}>
+                    {linkedRedirections.map((redirect) => (
+                      <div key={redirect.id}>
                         {redirect.domain_names.join(', ')} → {redirect.forward_domain_name}
                       </div>
                     ))}

--- a/src/hooks/useRedirectionHostColumns.tsx
+++ b/src/hooks/useRedirectionHostColumns.tsx
@@ -68,9 +68,9 @@ const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): Res
       mobileLabel: 'Sources',
       render: (value, item) => (
         <Box>
-          {item.domain_names.map((domain, index) => (
+          {item.domain_names.map((domain) => (
             <Box
-              key={index}
+              key={domain}
               sx={{
                 display: "flex",
                 alignItems: "center",

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,5 +1,15 @@
+import { useCallback } from 'react'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
+
+// Module-level constant — stable reference across renders
+const BREAKPOINT_VALUES = {
+  xs: 0,
+  sm: 600,
+  md: 850,  // Adjusted to account for container margins (~50px total)
+  lg: 1250,  // Adjusted to account for container margins
+  xl: 1920,
+} as const
 
 export interface UseResponsiveReturn {
   // Basic responsive states
@@ -55,33 +65,33 @@ export function useResponsive(): UseResponsiveReturn {
   const isSm = useMediaQuery(theme.breakpoints.up('sm'))
   
   // Helper function to get current breakpoint
-  const getCurrentBreakpoint = (): 'xs' | 'sm' | 'md' | 'lg' | 'xl' => {
+  const getCurrentBreakpoint = useCallback((): 'xs' | 'sm' | 'md' | 'lg' | 'xl' => {
     if (isXl) return 'xl'
     if (isLg) return 'lg'
     if (isMd) return 'md'
     if (isSm) return 'sm'
     return 'xs'
-  }
-  
+  }, [isXl, isLg, isMd, isSm])
+
   // Helper to check if screen is smaller than breakpoint
-  const isBelow = (breakpoint: 'sm' | 'md' | 'lg' | 'xl') => {
+  const isBelow = useCallback((breakpoint: 'sm' | 'md' | 'lg' | 'xl'): boolean => {
     switch (breakpoint) {
       case 'sm': return !isSm
       case 'md': return !isMd
       case 'lg': return !isLg
       case 'xl': return !isXl
     }
-  }
-  
+  }, [isSm, isMd, isLg, isXl])
+
   // Helper to check if screen is larger than breakpoint
-  const isAbove = (breakpoint: 'xs' | 'sm' | 'md' | 'lg') => {
+  const isAbove = useCallback((breakpoint: 'xs' | 'sm' | 'md' | 'lg'): boolean => {
     switch (breakpoint) {
       case 'xs': return true
       case 'sm': return isSm
       case 'md': return isMd
       case 'lg': return isLg
     }
-  }
+  }, [isSm, isMd, isLg])
   
   return {
     // Basic responsive states
@@ -101,13 +111,7 @@ export function useResponsive(): UseResponsiveReturn {
     isAbove,
     
     // Raw breakpoint values for custom logic
-    breakpoints: {
-      xs: 0,
-      sm: 600,
-      md: 850,  // Adjusted to account for container margins (~50px total)
-      lg: 1250,  // Adjusted to account for container margins
-      xl: 1920,
-    }
+    breakpoints: BREAKPOINT_VALUES
   }
 }
 

--- a/src/pages/AccessLists.tsx
+++ b/src/pages/AccessLists.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import {
   Box,
@@ -60,10 +60,23 @@ export default function AccessLists() {
   const [accessListToDelete, setAccessListToDelete] = useState<AccessList | null>(null)
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
 
+  const loadAccessLists = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await accessListsApi.getAll(['owner', 'items', 'clients'])
+      setAccessLists(data)
+    } catch (err: unknown) {
+      setError(getErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
   // Load access lists
   useEffect(() => {
     loadAccessLists()
-  }, [])
+  }, [loadAccessLists])
 
   // Handle URL-based navigation
   useEffect(() => {
@@ -84,19 +97,6 @@ export default function AccessLists() {
       }
     }
   }, [location.pathname, id, accessLists, canManageAccessLists])
-
-  const loadAccessLists = async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const data = await accessListsApi.getAll(['owner', 'items', 'clients'])
-      setAccessLists(data)
-    } catch (err: unknown) {
-      setError(getErrorMessage(err))
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const handleCreateAccessList = () => {
     navigate('/security/access-lists/new')

--- a/src/pages/AuditLog.tsx
+++ b/src/pages/AuditLog.tsx
@@ -43,7 +43,7 @@ import {
 } from '@mui/icons-material'
 import { format } from 'date-fns'
 import { auditLogApi, AuditLogEntry } from '../api/auditLog'
-import { useResponsive } from '../hooks/useResponsive'
+
 import PageHeader from '../components/PageHeader'
 import { DataTable } from '../components/DataTable'
 import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/ResponsiveTypes'
@@ -55,7 +55,6 @@ import { NAVIGATION_CONFIG, NAVIGATION_COLORS } from '../constants/navigation'
 const AuditLog = () => {
   const navigate = useNavigate()
   const theme = useTheme()
-  const { } = useResponsive() // eslint-disable-line no-empty-pattern
   const [logs, setLogs] = useState<AuditLogEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -219,9 +218,9 @@ const AuditLog = () => {
       )
     }
     
-    return items.map((item, index) => (
-      <Chip 
-        key={index} 
+    return items.map((item) => (
+      <Chip
+        key={item}
         label={item} 
         size="small" 
         sx={{ 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -286,9 +286,9 @@ const Dashboard = () => {
               </Grid>
               <Grid size={{ xs: 12, sm: 6 }}>
                 <Box sx={{ display: 'flex', gap: 1, justifyContent: { xs: 'flex-start', sm: 'flex-end' }, mt: { xs: 2, sm: 0 } }}>
-                  {quickActions.map((action, index) => (
+                  {quickActions.map((action) => (
                     <PermissionButton
-                      key={index}
+                      key={action.path}
                       resource={action.resource as Resource}
                       permissionAction="create"
                       variant="outlined"
@@ -327,8 +327,8 @@ const Dashboard = () => {
         </Grid>
 
         {/* Stats Cards */}
-        {statsCards.filter(card => card.show).map((card, index) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={index}>
+        {statsCards.filter(card => card.show).map((card) => (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={card.path}>
             <StatCard 
               {...card} 
               loading={stats.loading}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
   Box,
@@ -496,25 +496,7 @@ const Settings = () => {
     })
   ), [defaultSiteType, theme.shadows, theme.palette])
 
-  useEffect(() => {
-    fetchSettings()
-  }, [])
-  
-  // Update active tab when URL changes
-  useEffect(() => {
-    if (tab && tabNameToIndex[tab] !== undefined) {
-      const newTabIndex = tabNameToIndex[tab]
-      if (newTabIndex !== activeTab) {
-        setActiveTab(newTabIndex)
-      }
-    } else if (!tab && activeTab !== 0) {
-      setActiveTab(0)
-    }
-    // tabNameToIndex is a constant, so it's safe to exclude from dependencies
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, activeTab])
-
-  const fetchSettings = async (showLoader = true) => {
+  const fetchSettings = useCallback(async (showLoader = true) => {
     try {
       if (showLoader) {
         setLoading(true)
@@ -546,7 +528,25 @@ const Settings = () => {
         setLoading(false)
       }
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    fetchSettings()
+  }, [fetchSettings])
+
+  // Update active tab when URL changes
+  useEffect(() => {
+    if (tab && tabNameToIndex[tab] !== undefined) {
+      const newTabIndex = tabNameToIndex[tab]
+      if (newTabIndex !== activeTab) {
+        setActiveTab(newTabIndex)
+      }
+    } else if (!tab && activeTab !== 0) {
+      setActiveTab(0)
+    }
+    // tabNameToIndex is a constant, so it's safe to exclude from dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, activeTab])
 
   const handleSaveDefaultSite = async () => {
     try {

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -56,9 +56,22 @@ const Users = () => {
   const { isMobileTable } = useResponsive()
   const isAdmin = currentUser?.roles?.includes('admin')
 
+  const loadUsers = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await usersApi.getAll(['permissions'])
+      setUsers(data)
+    } catch (err: unknown) {
+      setError(getErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
   useEffect(() => {
     loadUsers()
-  }, [])
+  }, [loadUsers])
 
   // Handle URL parameter for viewing/editing
   useEffect(() => {
@@ -76,19 +89,6 @@ const Users = () => {
       setSelectedUser(null)
     }
   }, [id, users])
-
-  const loadUsers = async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const data = await usersApi.getAll(['permissions'])
-      setUsers(data)
-    } catch (err: unknown) {
-      setError(getErrorMessage(err))
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const handleRowClick = useCallback((user: User) => {
     setSelectedUser(user)
@@ -156,7 +156,7 @@ const Users = () => {
       showSuccess('user', 'disabled', `${successCount} user${successCount > 1 ? 's' : ''}`)
       await loadUsers()
     }
-  }, [currentUser?.id, showError, showSuccess])
+  }, [currentUser?.id, showError, showSuccess, loadUsers])
 
   const handleBulkEnable = useCallback(async (users: User[]) => {
     const eligibleUsers = users.filter(u => u.is_disabled && u.id !== currentUser?.id)
@@ -177,7 +177,7 @@ const Users = () => {
       showSuccess('user', 'enabled', `${successCount} user${successCount > 1 ? 's' : ''}`)
       await loadUsers()
     }
-  }, [currentUser?.id, showError, showSuccess])
+  }, [currentUser?.id, showError, showSuccess, loadUsers])
 
 
   const handleLoginAs = useCallback(async (user: User) => {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,19 +1,8 @@
 import type { Owner } from './base'
-import { Certificate } from '../api/certificates'
-import { AccessList } from '../api/accessLists'
+import type { Certificate } from '../api/certificates'
 
 // Re-export Owner from base types for backward compatibility
 export type { Owner }
-
-// Extended certificate type with proper relations
-export interface CertificateWithRelations extends Omit<Certificate, 'owner'> {
-  owner?: Owner
-}
-
-// Extended access list type with proper relations
-export interface AccessListWithRelations extends Omit<AccessList, 'owner'> {
-  owner?: Owner
-}
 
 /**
  * Shape of the NPM API error response body.
@@ -84,29 +73,4 @@ export interface CertificateWithHosts extends Certificate {
   proxy_hosts?: CertificateHostRelation[]
   redirection_hosts?: CertificateHostRelation[]
   dead_hosts?: CertificateHostRelation[]
-}
-
-// React event types
-export type ChangeEvent<T = HTMLInputElement> = React.ChangeEvent<T>
-export type MouseEvent<T = HTMLElement> = React.MouseEvent<T>
-export type FormEvent<T = HTMLFormElement> = React.FormEvent<T>
-export type KeyboardEvent<T = HTMLElement> = React.KeyboardEvent<T>
-
-// Common handler types
-export type ChangeHandler<T = HTMLInputElement> = (event: ChangeEvent<T>) => void
-export type ClickHandler<T = HTMLElement> = (event: MouseEvent<T>) => void
-export type SubmitHandler<T = HTMLFormElement> = (event: FormEvent<T>) => void
-
-// Pagination types
-export interface PaginationState {
-  page: number
-  rowsPerPage: number
-}
-
-// Sort types
-export type SortDirection = 'asc' | 'desc'
-
-export interface SortState<T> {
-  orderBy: T
-  order: SortDirection
 }


### PR DESCRIPTION
## Summary

Post-audit cleanup for Epic #41, addressing remaining issues across cleanup, memoization, and consistency categories found by TypeScript, React, and architecture specialists.

### Quick Wins
- Remove unused `useResponsive()` call and import from AuditLog
- Remove ~25 lines of unused type definitions from `types/common.ts` (CertificateWithRelations, AccessListWithRelations, event/handler types, pagination/sort types)
- Replace `key={index}` with stable keys at 6 locations across 4 files
- Remove outdated TODO comment and commented-out MUI imports

### Medium Effort
- Fix missing `useEffect` dependencies in AccessLists, Users, Settings by wrapping load functions in `useCallback`
- Stabilize `useResponsive` hook with `useCallback` for utility functions and module-level constant for breakpoints
- Unify error types in ProxyHostDrawer tab components from `Record<string, string>` to `Partial<Record<keyof ProxyHostFormData, string>>`
- Extract shared `ToastAlertContent` component to eliminate ~60 lines of JSX duplication in ToastContext

Closes #77

## Test Plan

- [ ] Verify lint passes: `pnpm run lint` (0 errors, 0 warnings)
- [ ] Verify typecheck passes: `pnpm run typecheck` (0 errors)
- [ ] Verify build succeeds: `pnpm run build`
- [ ] Verify AuditLog page loads correctly without useResponsive
- [ ] Verify toast notifications display correctly (both demo and non-demo modes)
- [ ] Verify proxy hosts table renders domain names correctly with stable keys
- [ ] Verify Dashboard quick actions and stats cards render correctly
- [ ] Verify ProxyHostDrawer form validation errors display correctly
- [ ] Verify AccessLists, Users, and Settings pages load data on mount