### PR TITLE
refactor: extract certificate expiry thresholds and magic numbers to constants

### DIFF
--- a/src/components/RedirectionHostDetailsDialog.tsx
+++ b/src/components/RedirectionHostDetailsDialog.tsx
@@ -30,6 +30,7 @@ import { getStatusColor, getStatusText } from '../utils/statusUtils'
 import { getDaysUntilExpiry } from '../utils/dateUtils'
 import AdaptiveContainer from './AdaptiveContainer'
 import { NAVIGATION_COLORS } from '../constants/navigation'
+import { CERTIFICATE_EXPIRY } from '../constants/certificates'
 
 interface RedirectionHostDetailsDialogProps {
   open: boolean
@@ -50,8 +51,8 @@ export default function RedirectionHostDetailsDialog({
     if (!host.certificate?.expires_on) return null
     const days = getDaysUntilExpiry(host.certificate.expires_on)
     if (!days || days < 0) return { color: 'error' as const, text: 'Expired' }
-    if (days <= 7) return { color: 'error' as const, text: `Expires in ${days} days` }
-    if (days <= 30) return { color: 'warning' as const, text: `Expires in ${days} days` }
+    if (days <= CERTIFICATE_EXPIRY.CRITICAL_DAYS) return { color: 'error' as const, text: `Expires in ${days} days` }
+    if (days <= CERTIFICATE_EXPIRY.WARNING_DAYS) return { color: 'warning' as const, text: `Expires in ${days} days` }
     return { color: 'success' as const, text: `Valid for ${days} days` }
   }
 

--- a/src/components/features/certificates/CertificateInfoPanel.tsx
+++ b/src/components/features/certificates/CertificateInfoPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { Certificate } from '../../../api/certificates'
 import { getDaysUntilExpiry, formatDate } from '../../../utils/dateUtils'
 import OwnerDisplay from '../../shared/OwnerDisplay'
+import { CERTIFICATE_EXPIRY } from '../../../constants/certificates'
 
 interface CertificateInfoPanelProps {
   certificate: Certificate
@@ -36,7 +37,7 @@ const CertificateInfoPanel = ({
 }: CertificateInfoPanelProps) => {
   const daysUntilExpiry = getDaysUntilExpiry(certificate.expires_on)
   const isExpired = daysUntilExpiry !== null && daysUntilExpiry < 0
-  const isExpiringSoon = daysUntilExpiry !== null && daysUntilExpiry <= 30
+  const isExpiringSoon = daysUntilExpiry !== null && daysUntilExpiry <= CERTIFICATE_EXPIRY.WARNING_DAYS
 
   return (
     <Grid container spacing={3}>

--- a/src/components/shared/CertificateSelector.tsx
+++ b/src/components/shared/CertificateSelector.tsx
@@ -17,6 +17,7 @@ import {
   Error as ErrorIcon,
 } from '@mui/icons-material'
 import { Certificate } from '../../api/certificates'
+import { CERTIFICATE_EXPIRY } from '../../constants/certificates'
 
 interface NewCertificateOption {
   id: 'new'
@@ -77,7 +78,7 @@ export default function CertificateSelector({
         text: 'Expired',
         icon: ErrorIcon
       }
-    } else if (daysUntilExpiry < 30) {
+    } else if (daysUntilExpiry < CERTIFICATE_EXPIRY.WARNING_DAYS) {
       return {
         color: 'warning' as const,
         text: `Expires in ${daysUntilExpiry} days`,

--- a/src/constants/certificates.ts
+++ b/src/constants/certificates.ts
@@ -1,0 +1,9 @@
+/**
+ * Certificate expiry threshold constants
+ */
+export const CERTIFICATE_EXPIRY = {
+  /** Days threshold for critical/error status */
+  CRITICAL_DAYS: 7,
+  /** Days threshold for warning status */
+  WARNING_DAYS: 30,
+} as const

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -6,4 +6,6 @@ export const LAYOUT = {
   DRAWER_WIDTH: 240,
   /** Top toolbar height in pixels */
   TOOLBAR_HEIGHT: 64,
+  /** Breakpoint width (px) for compact table layout */
+  COMPACT_BREAKPOINT: 1250,
 } as const

--- a/src/hooks/useDashboardStats.ts
+++ b/src/hooks/useDashboardStats.ts
@@ -13,6 +13,7 @@ import type { AccessList } from '../api/accessLists'
 import { usePermissions } from './usePermissions'
 import { getDaysUntilExpiry } from '../utils/dateUtils'
 import logger from '../utils/logger'
+import { CERTIFICATE_EXPIRY } from '../constants/certificates'
 
 export interface DashboardStats {
   proxyHosts: {
@@ -121,7 +122,7 @@ export const useDashboardStats = (): DashboardStats => {
           
           if (days < 0) {
             expiredCount++
-          } else if (days <= 30) {
+          } else if (days <= CERTIFICATE_EXPIRY.WARNING_DAYS) {
             expiringSoonCount++
             expiringCerts.push(cert)
           } else {

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,13 +1,14 @@
 import { useCallback } from 'react'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
+import { LAYOUT } from '../constants/layout'
 
 // Module-level constant — stable reference across renders
 const BREAKPOINT_VALUES = {
   xs: 0,
   sm: 600,
   md: 850,  // Adjusted to account for container margins (~50px total)
-  lg: 1250,  // Adjusted to account for container margins
+  lg: LAYOUT.COMPACT_BREAKPOINT,  // Adjusted to account for container margins
   xl: 1920,
 } as const
 
@@ -52,8 +53,8 @@ export function useResponsive(): UseResponsiveReturn {
   
   // Specific breakpoints for tables
   const isMobileTable = useMediaQuery('(max-width:900px)') // < 900px (use cards)
-  const isCompactTable = useMediaQuery('(min-width:901px) and (max-width:1250px)') // 901px - 1250px (hide some columns)
-  const isFullTable = useMediaQuery('(min-width:1251px)') // >= 1251px (all columns)
+  const isCompactTable = useMediaQuery(`(min-width:901px) and (max-width:${LAYOUT.COMPACT_BREAKPOINT}px)`) // 901px - compact breakpoint (hide some columns)
+  const isFullTable = useMediaQuery(`(min-width:${LAYOUT.COMPACT_BREAKPOINT + 1}px)`) // > compact breakpoint (all columns)
   
   // Extra small screens for very mobile-friendly layouts
   const isExtraSmall = useMediaQuery('(max-width:480px)') // < 480px (very compact cards)

--- a/src/pages/AccessLists.tsx
+++ b/src/pages/AccessLists.tsx
@@ -37,6 +37,7 @@ import { DataTable } from '../components/DataTable'
 import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/ResponsiveTypes'
 import { Filter, BulkAction } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
+import { LAYOUT } from '../constants/layout'
 
 export default function AccessLists() {
   const { isAdmin } = usePermissions()
@@ -371,7 +372,7 @@ export default function AccessLists() {
           rowsPerPageOptions={[10, 25, 50, 100]}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}

--- a/src/pages/AuditLog.tsx
+++ b/src/pages/AuditLog.tsx
@@ -51,6 +51,7 @@ import { Filter } from '../components/DataTable/types'
 import { useToast } from '../contexts/ToastContext'
 import ActionChip from '../components/shared/ActionChip'
 import { NAVIGATION_CONFIG, NAVIGATION_COLORS } from '../constants/navigation'
+import { LAYOUT } from '../constants/layout'
 
 const AuditLog = () => {
   const navigate = useNavigate()
@@ -438,7 +439,7 @@ const AuditLog = () => {
           stickyHeader
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
       </Box>
       <Dialog

--- a/src/pages/Certificates.tsx
+++ b/src/pages/Certificates.tsx
@@ -43,6 +43,8 @@ import { createStandardBulkActions } from '../utils/bulkActionFactory'
 import { extractBaseDomain } from '../utils/domainUtils'
 import { getDaysUntilExpiry } from '../utils/dateUtils'
 import { STORAGE_KEYS } from '../constants/storage'
+import { CERTIFICATE_EXPIRY } from '../constants/certificates'
+import { LAYOUT } from '../constants/layout'
 
 const getCertDisplayName = (cert: Certificate): string =>
   cert.nice_name || cert.domain_names[0] || 'Unnamed Certificate'
@@ -138,9 +140,9 @@ const Certificates = () => {
 
     if (daysUntilExpiry < 0) {
       return <Chip label="Expired" color="error" size="small" icon={<WarningIcon />} />
-    } else if (daysUntilExpiry <= 7) {
+    } else if (daysUntilExpiry <= CERTIFICATE_EXPIRY.CRITICAL_DAYS) {
       return <Chip label={`${daysUntilExpiry} days`} color="error" size="small" />
-    } else if (daysUntilExpiry <= 30) {
+    } else if (daysUntilExpiry <= CERTIFICATE_EXPIRY.WARNING_DAYS) {
       return <Chip label={`${daysUntilExpiry} days`} color="warning" size="small" />
     } else {
       return <Chip label={`${daysUntilExpiry} days`} color="success" size="small" />
@@ -421,7 +423,7 @@ const Certificates = () => {
           showGroupToggle={true}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button with Menu - shown at bottom */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -40,6 +40,7 @@ import PermissionButton from '../components/PermissionButton'
 import { Resource } from '../types/permissions'
 import { getDaysUntilExpiry } from '../utils/dateUtils'
 import { NAVIGATION_COLORS } from '../constants/navigation'
+import { CERTIFICATE_EXPIRY } from '../constants/certificates'
 
 interface StatCardProps {
   title: string
@@ -352,7 +353,7 @@ const Dashboard = () => {
                   {stats.expiringCertificates.slice(0, 5).map((cert, index) => {
                     const days = getDaysUntilExpiry(cert.expires_on) || 0
                     const isExpired = days < 0
-                    const isCritical = days <= 7
+                    const isCritical = days <= CERTIFICATE_EXPIRY.CRITICAL_DAYS
                     
                     return (
                       <React.Fragment key={cert.id}>

--- a/src/pages/DeadHosts.tsx
+++ b/src/pages/DeadHosts.tsx
@@ -36,6 +36,7 @@ import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/R
 import { Filter, FilterValue } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { getStatusIcon } from '../utils/statusUtils'
+import { LAYOUT } from '../constants/layout'
 
 export default function DeadHosts() {
   const { showSuccess, showError, showWarning } = useToast()
@@ -332,7 +333,7 @@ export default function DeadHosts() {
           rowsPerPageOptions={[10, 25, 50, 100]}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}

--- a/src/pages/ProxyHosts.tsx
+++ b/src/pages/ProxyHosts.tsx
@@ -23,6 +23,7 @@ import PageHeader from '../components/PageHeader'
 import { useToast } from '../contexts/ToastContext'
 import { DataTable } from '../components/DataTable'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
+import { LAYOUT } from '../constants/layout'
 
 /** Type for the redirection lookup map loaded as additional data */
 type RedirectionsByTarget = Map<string, RedirectionHost[]>
@@ -184,7 +185,7 @@ export default function ProxyHosts() {
           showGroupToggle={true}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}

--- a/src/pages/RedirectionHosts.tsx
+++ b/src/pages/RedirectionHosts.tsx
@@ -23,6 +23,7 @@ import PageHeader from '../components/PageHeader'
 import { useToast } from '../contexts/ToastContext'
 import { DataTable } from '../components/DataTable'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
+import { LAYOUT } from '../constants/layout'
 
 /** Builds a domain-to-ProxyHost lookup map from proxy hosts data */
 const buildProxyHostDomainMap = async (): Promise<Map<string, ProxyHost>> => {
@@ -167,7 +168,7 @@ export default function RedirectionHosts() {
           showGroupToggle={true}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -38,6 +38,7 @@ import { Filter, FilterValue } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { getStatusIcon } from '../utils/statusUtils'
 import { createStandardBulkActions } from '../utils/bulkActionFactory'
+import { LAYOUT } from '../constants/layout'
 
 /** Build a display name for a stream (e.g. "8080/TCP" or "53/TCPUDP"). */
 const getStreamDisplayName = (stream: Stream): string =>
@@ -405,7 +406,7 @@ export default function Streams() {
           rowsPerPageOptions={[10, 25, 50, 100]}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -37,6 +37,7 @@ import { ResponsiveTableColumn, ColumnPriority } from '../components/DataTable/R
 import { Filter, BulkAction } from '../components/DataTable/types'
 import { NAVIGATION_CONFIG } from '../constants/navigation'
 import { STORAGE_KEYS } from '../constants/storage'
+import { LAYOUT } from '../constants/layout'
 
 const Users = () => {
   const { user: currentUser, pushCurrentToStack } = useAuthStore()
@@ -442,7 +443,7 @@ const Users = () => {
           rowsPerPageOptions={[10, 25, 50, 100]}
           responsive={true}
           cardBreakpoint={900}
-          compactBreakpoint={1250}
+          compactBreakpoint={LAYOUT.COMPACT_BREAKPOINT}
         />
 
         {/* Mobile Add Button - shown at bottom */}


### PR DESCRIPTION
## Summary

- Extract certificate expiry thresholds (7 critical / 30 warning days) to `CERTIFICATE_EXPIRY` constant in `src/constants/certificates.ts`
- Extract compact table breakpoint (1250px) to `LAYOUT.COMPACT_BREAKPOINT` in `src/constants/layout.ts`
- Replace all 8 hardcoded certificate expiry usages across 6 files
- Replace all 10 hardcoded compactBreakpoint usages across 9 files (8 pages + useResponsive.ts)
- No behavioral changes

Closes #84

## Test plan

- [x] Verify certificate expiry chips show correct colors (error <= 7 days, warning <= 30 days, success > 30 days)
- [x] Verify dashboard expiring certificates section uses correct thresholds
- [x] Verify responsive table layout switches at 1250px breakpoint on all pages
- [x] Run `pnpm run lint` — passes
- [x] Run `pnpm run typecheck` — passes