### PR TITLE
refactor: add explicit return type interfaces to hooks (#106)

### DIFF
--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -6,13 +6,18 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { TIMING } from '../constants/timing'
 
+export interface UseCopyToClipboardReturn {
+  copiedText: string
+  copyToClipboard: (text: string, label?: string) => void
+}
+
 /**
  * Hook that provides clipboard copy functionality with a temporary feedback state.
  *
  * @param resetDelay - Time in ms before copiedText resets to empty (default: TIMING.CLIPBOARD_RESET)
  * @returns Object with copiedText state and copyToClipboard function
  */
-export function useCopyToClipboard(resetDelay = TIMING.CLIPBOARD_RESET) {
+export function useCopyToClipboard(resetDelay = TIMING.CLIPBOARD_RESET): UseCopyToClipboardReturn {
   const [copiedText, setCopiedText] = useState<string>('')
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 

--- a/src/hooks/useDomainGroupConfig.tsx
+++ b/src/hooks/useDomainGroupConfig.tsx
@@ -14,12 +14,14 @@ interface DomainEntity {
   domain_names: string[]
 }
 
+export type UseDomainGroupConfigReturn<T extends DomainEntity> = GroupConfig<T>
+
 /**
  * Custom hook that provides a shared GroupConfig for domain-based grouping.
  * Used by both ProxyHosts and RedirectionHosts DataTables to group items
  * by their base domain (e.g. "example.com" groups "api.example.com" and "www.example.com").
  */
-const useDomainGroupConfig = <T extends DomainEntity>(): GroupConfig<T> => {
+const useDomainGroupConfig = <T extends DomainEntity>(): UseDomainGroupConfigReturn<T> => {
   const groupConfig = useMemo<GroupConfig<T>>(() => ({
     groupBy: (item) => {
       const mainDomain = item.domain_names[0] || ''

--- a/src/hooks/useDrawerForm.ts
+++ b/src/hooks/useDrawerForm.ts
@@ -82,6 +82,35 @@ interface FormState<T> {
 }
 
 /**
+ * Return type for useDrawerForm — exposes the FormState plus actions and helpers.
+ */
+export interface UseDrawerFormReturn<T> extends FormState<T> {
+  setFormData: (updates: Partial<T> | ((prev: T) => T)) => void;
+  setFieldValue: (key: keyof T, value: T[keyof T]) => void;
+  setFieldTouched: (key: keyof T, touched?: boolean) => void;
+  resetForm: (newInitialData?: T) => void;
+  handleSubmit: (event?: React.FormEvent) => Promise<void>;
+  markAsClean: () => void;
+  /**
+   * Note: `value` is typed `string` to match what TypeScript infers from the
+   * `formState.data[key] ?? ''` expression under the recursive generic constraint.
+   * At runtime, value can be boolean or number for non-string form fields —
+   * coerce explicitly when binding to typed input components.
+   */
+  getFieldProps: (key: keyof T) => {
+    name: string;
+    value: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+    onBlur: () => void;
+    error: boolean;
+    helperText: string | undefined;
+    disabled: boolean;
+  };
+  validateField: (key: keyof T, value: T[keyof T], data?: T) => string | null;
+  validateAllFields: (data: T) => Record<keyof T, string>;
+}
+
+/**
  * Default equality function for dirty checking
  */
 const defaultIsEqual = <T>(a: T, b: T): boolean => {
@@ -148,7 +177,7 @@ export const useDrawerForm = <T extends { [K in keyof T]: T[K] }>({
   autoSave,
   isEqual = defaultIsEqual,
   resetOnSubmit = false,
-}: UseDrawerFormOptions<T>) => {
+}: UseDrawerFormOptions<T>): UseDrawerFormReturn<T> => {
   // Form state
   const [formState, setFormState] = useState<FormState<T>>(() => ({
     data: { ...initialData },

--- a/src/hooks/useFilteredData.ts
+++ b/src/hooks/useFilteredData.ts
@@ -6,9 +6,11 @@ interface HasOwnerId {
   owner?: { id: number }
 }
 
+export type UseFilteredDataReturn<T> = T[]
+
 export function useFilteredData<T>(
   data: T[]
-): T[] {
+): UseFilteredDataReturn<T> {
   const { user, shouldFilterByUser } = useAuthStore()
 
   return useMemo(() => {

--- a/src/hooks/useProxyHostColumns.tsx
+++ b/src/hooks/useProxyHostColumns.tsx
@@ -37,11 +37,13 @@ interface UseProxyHostColumnsParams {
   navigate: NavigateFunction
 }
 
+export type UseProxyHostColumnsReturn = ResponsiveTableColumn<ProxyHost>[]
+
 /**
  * Custom hook that provides column definitions for the proxy hosts DataTable.
  * Extracts the column configuration including render functions, sorting, and responsive priorities.
  */
-const useProxyHostColumns = (params: UseProxyHostColumnsParams): ResponsiveTableColumn<ProxyHost>[] => {
+const useProxyHostColumns = (params: UseProxyHostColumnsParams): UseProxyHostColumnsReturn => {
   const { redirectionsByTarget, onToggleEnabled, onEdit, onDelete, onViewConnections, onViewAccess, navigate } = params
 
   /** Get redirection hosts that point to any of the proxy host's domains */

--- a/src/hooks/useRedirectionHostColumns.tsx
+++ b/src/hooks/useRedirectionHostColumns.tsx
@@ -37,11 +37,13 @@ interface UseRedirectionHostColumnsParams {
   navigate: NavigateFunction
 }
 
+export type UseRedirectionHostColumnsReturn = ResponsiveTableColumn<RedirectionHost>[]
+
 /**
  * Custom hook that provides column definitions for the redirection hosts DataTable.
  * Extracts the column configuration including render functions, sorting, and responsive priorities.
  */
-const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): ResponsiveTableColumn<RedirectionHost>[] => {
+const useRedirectionHostColumns = (params: UseRedirectionHostColumnsParams): UseRedirectionHostColumnsReturn => {
   const { proxyHostsByDomain, onToggleEnabled, onEdit, onDelete, onViewProxyHost } = params
 
   const columns = useMemo<ResponsiveTableColumn<RedirectionHost>[]>(() => [


### PR DESCRIPTION
## Summary

- Adds exported return-type annotations to 6 hooks that previously relied on TypeScript inference: `useCopyToClipboard`, `useDrawerForm`, `useFilteredData`, `useDomainGroupConfig`, `useProxyHostColumns`, `useRedirectionHostColumns`
- Strategy: `interface` for object returns (2), `type` alias for array / re-aliased generic returns (4) — idiomatic TypeScript for non-object shapes
- Net +48/-6 lines across 6 files; no runtime behavior changed

## Why

Issue #106 audit found ~50% of NPMDeck hooks lacked explicit return type interfaces. Even though TypeScript inference is type-safe, explicit named return types improve IDE autocomplete, surface the hook's public API in tooling, and serve as living documentation. This PR closes the consistency gap for v1.0.

## Implementation Notes

`UseDrawerFormReturn.getFieldProps.value` is typed `string` to match TypeScript's actual inference under the hook's recursive generic constraint (`T extends { [K in keyof T]: T[K] }`). A JSDoc warning above the field documents that at runtime the value can be `boolean | number` for non-string form fields — consumers should coerce explicitly when binding to typed input components.

## Acceptance Criteria

- [x] Each listed hook has an exported return-type (interface or type alias depending on return shape)
- [x] Hook signature uses the explicit return type annotation
- [x] All existing consumers still work (no type errors)
- [x] Typecheck and lint pass

## Test Plan

- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm run lint` — 0 errors/warnings
- [x] `pnpm run test` — 324/324 tests passing (includes useDrawerForm test suite)
- [x] `pnpm run build` — succeeds
- [x] Independent code review via superpowers:code-reviewer — both Important findings (verbose `helperText` type, undocumented `value: string` runtime widening) addressed before commit

## Follow-up (out of scope)

The 5 reference hooks (`useResponsive`, `usePermissions`, `useNavigationMenu`, `useProxyHostFilters`, `useRedirectionHostFilters`) currently have **local** (non-exported) return interfaces. After this PR, the codebase will have a minor convention split. A follow-up issue could migrate them to exported interfaces for full consistency.

Closes #106